### PR TITLE
アカウント作成/インポートウィザード中のアカウント作成/インポートボタンの移動

### DIFF
--- a/src/components/Registration/Welcome.tsx
+++ b/src/components/Registration/Welcome.tsx
@@ -51,23 +51,6 @@ export function RegistrationWelcome(props: { next: () => void; identity: Identit
                     IDカードを作成する
                 </Button>
             </Box>
-
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    gap: '10px',
-                    alignItems: 'center',
-                    position: 'absolute',
-                    right: '10px',
-                    bottom: '10px'
-                }}
-            >
-                <Typography>もうアカウントを持っている？</Typography>
-                <Button variant="contained" component={RouterLink} to="/import">
-                    アカウントのインポート
-                </Button>
-            </Box>
         </>
     )
 }

--- a/src/pages/AccountImport.tsx
+++ b/src/pages/AccountImport.tsx
@@ -239,7 +239,7 @@ export function AccountImport(): JSX.Element {
                         alignItems: 'center'
                     }}
                 >
-                    <Typography>まだアカウントを作ってない？</Typography>
+                    <Typography color={theme.palette.background.contrastText}>まだアカウントを作ってない？</Typography>
                     <Button variant="contained" component={Link} to="/register">
                         アカウントを作成
                     </Button>

--- a/src/pages/AccountImport.tsx
+++ b/src/pages/AccountImport.tsx
@@ -229,22 +229,21 @@ export function AccountImport(): JSX.Element {
                     <Button disabled={!entityFound} variant="contained" onClick={accountImport}>
                         インポート
                     </Button>
-                    <Box sx={{ flexGrow: 1 }} />
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            justifyContent: 'flex-end',
-                            gap: '10px',
-                            alignItems: 'center'
-                        }}
-                    >
-                        <Typography>まだアカウントを作ってない？</Typography>
-                        <Button variant="contained" component={Link} to="/register">
-                            アカウントを作成
-                        </Button>
-                    </Box>
                 </Paper>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        justifyContent: 'flex-end',
+                        gap: '10px',
+                        alignItems: 'center'
+                    }}
+                >
+                    <Typography>まだアカウントを作ってない？</Typography>
+                    <Button variant="contained" component={Link} to="/register">
+                        アカウントを作成
+                    </Button>
+                </Box>
             </Box>
         </ThemeProvider>
     )

--- a/src/pages/Registration.tsx
+++ b/src/pages/Registration.tsx
@@ -322,7 +322,9 @@ export function Registration(): JSX.Element {
                                 alignItems: 'center'
                             }}
                         >
-                            <Typography>もうアカウントを持っている？</Typography>
+                            <Typography color={theme.palette.background.contrastText}>
+                                もうアカウントを持っている？
+                            </Typography>
                             <Button variant="contained" component={Link} to="/import">
                                 アカウントのインポート
                             </Button>

--- a/src/pages/Registration.tsx
+++ b/src/pages/Registration.tsx
@@ -26,6 +26,7 @@ import { ChooseDomain } from '../components/Registration/ChooseDomain'
 import { CreateProfile } from '../components/Registration/CreateProfile'
 import { RegistrationReady } from '../components/Registration/LetsGo'
 import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 
 export function Registration(): JSX.Element {
     const { i18n } = useTranslation('', { keyPrefix: 'registration' })
@@ -311,6 +312,22 @@ export function Registration(): JSX.Element {
                             }}
                         ></Box>
                     </Paper>
+                    {activeStep === 0 && (
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end',
+                                gap: '10px',
+                                alignItems: 'center'
+                            }}
+                        >
+                            <Typography>もうアカウントを持っている？</Typography>
+                            <Button variant="contained" component={Link} to="/import">
+                                アカウントのインポート
+                            </Button>
+                        </Box>
+                    )}
                 </Box>
             </ApiProvider>
         </ThemeProvider>


### PR DESCRIPTION
paper外に出すことで「次へ」ボタンのつもりで押してしまう操作ミスを減らす