### PR TITLE
画像投稿設定でS3だけが設定済みの場合、画像添付ができなかった不具合を修正

### DIFF
--- a/src/components/Draft.tsx
+++ b/src/components/Draft.tsx
@@ -472,10 +472,10 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
             >
                 <Box>
                     <Tooltip
-                        title={pref.imgurClientID === '' ? t('cantAttachImage') : t('attachImage')}
+                        title={pref.imgurClientID === '' && pref.s3Config.endpoint === '' ? t('cantAttachImage') : t('attachImage')}
                         arrow
                         placement="top"
-                        enterDelay={pref.imgurClientID === '' ? 0 : 500}
+                        enterDelay={pref.imgurClientID === '' && pref.s3Config.endpoint === '' ? 0 : 500}
                     >
                         <span>
                             <IconButton
@@ -483,7 +483,7 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
                                     color: theme.palette.text.secondary
                                 }}
                                 onClick={() => {
-                                    if (pref.imgurClientID === '') {
+                                    if (pref.imgurClientID === '' && pref.s3Config.endpoint === '') {
                                         navigate('/settings/media')
                                     } else {
                                         onFileUploadClick()


### PR DESCRIPTION
Tooltipの条件判定でS3の設定を見るように修正しました。一旦 `pref.s3Config.endpoint` だけで判別しています。