### PR TITLE
スマホでDraftを表示したとき投稿内容が長いと上部のボタン類が隠れる問題を修正

### DIFF
--- a/src/context/GlobalActions.tsx
+++ b/src/context/GlobalActions.tsx
@@ -33,11 +33,13 @@ interface GlobalActionsProps {
 
 const style = {
     position: 'absolute',
-    top: '30%',
+    top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
     width: '700px',
-    maxWidth: '90vw'
+    maxWidth: '90vw',
+    maxHeight: '90vh',
+    overflow: 'scroll'
 }
 
 export const GlobalActionsProvider = (props: GlobalActionsProps): JSX.Element => {


### PR DESCRIPTION
モバイルでの投稿時、キーボード表示により極端に画面の縦幅が短くなった際にモーダルの上部がはみ出てボタンにアクセスできなくなる不具合を修正しました。

左: 修正後 右: 修正前
![image](https://github.com/totegamma/concurrent-world/assets/29700428/a6754f7c-aa0d-40ac-ae69-8d6b8a451ee3)

- `maxHeight` と `overflow` の指定ではみ出した際の挙動を設定
- スペースの有効活用のためモーダルを中心に移動
  - 変更前の `top: 30%` になにか意匠があれば戻します :bow: 

... 全体のスクロールで収めるのではなく、プレビュー部分のみのスクロールにするか迷いましたが、concurrentの仕様上Markdownのプレビューは重要度が高いと思うので全体にしました。一旦ドラフトで出します。
