### PR TITLE
テーマのロゴの表示方法を変えました

### DIFF
--- a/src/components/ThemeCard.tsx
+++ b/src/components/ThemeCard.tsx
@@ -19,8 +19,8 @@ export const ThemeCard = (props: ThemeCardProps): JSX.Element => {
 
     const bgColor =
         theme.components?.MuiAppBar?.defaultProps?.color === 'transparent'
-            ? theme.palette.background.paper
-            : theme.palette.primary.contrastText
+            ? theme.palette.primary.main
+            : theme.palette.background.default
 
     return (
         <Paper variant="outlined">
@@ -40,14 +40,14 @@ export const ThemeCard = (props: ThemeCardProps): JSX.Element => {
                     sx={{
                         display: 'flex',
                         borderRadius: '100px',
-                        background: bgColor
+                        background: theme.palette.primary.contrastText
                     }}
                 >
                     <ConcurrentLogo
                         size="40px"
                         upperColor={theme.palette.primary.main}
-                        lowerColor={theme.palette.background.default}
-                        frameColor={theme.palette.background.default}
+                        lowerColor={bgColor}
+                        frameColor={bgColor}
                     />
                 </Box>
                 <Typography

--- a/src/components/ThemeCard.tsx
+++ b/src/components/ThemeCard.tsx
@@ -17,6 +17,11 @@ export const ThemeCard = (props: ThemeCardProps): JSX.Element => {
 
     const theme = createConcurrentThemeFromObject(props.theme)
 
+    const bgColor =
+        theme.components?.MuiAppBar?.defaultProps?.color === 'transparent'
+            ? theme.palette.background.paper
+            : theme.palette.primary.contrastText
+
     return (
         <Paper variant="outlined">
             <Button
@@ -35,7 +40,7 @@ export const ThemeCard = (props: ThemeCardProps): JSX.Element => {
                     sx={{
                         display: 'flex',
                         borderRadius: '100px',
-                        background: theme.palette.primary.contrastText
+                        background: bgColor
                     }}
                 >
                     <ConcurrentLogo


### PR DESCRIPTION
テーマのAppBar Styleにtransparentが設定されている場合にロゴのbackgrowndの色をbackground.paperの色を設定し透過しているよう見えるようにしました。