### PR TITLE
サブプロフィール機能の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.445.0",
-        "@concurrent-world/client": "^4.2.9",
+        "@concurrent-world/client": "^4.2.10",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.445.0",
-        "@concurrent-world/client": "^4.2.12",
+        "@concurrent-world/client": "^4.2.13",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.445.0",
-        "@concurrent-world/client": "^4.2.8",
+        "@concurrent-world/client": "^4.2.9",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.445.0",
-        "@concurrent-world/client": "^4.2.13",
+        "@concurrent-world/client": "^4.2.14",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.445.0",
-        "@concurrent-world/client": "^4.2.11",
+        "@concurrent-world/client": "^4.2.12",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.445.0",
         "@aws-sdk/s3-request-presigner": "^3.445.0",
-        "@concurrent-world/client": "^4.2.10",
+        "@concurrent-world/client": "^4.2.11",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@concurrent-world/client':
-    specifier: ^4.2.11
-    version: 4.2.11
+    specifier: ^4.2.12
+    version: 4.2.12
   '@emotion/react':
     specifier: ^11.10.5
     version: 11.10.5(@babel/core@7.21.8)(@types/react@18.0.26)(react@18.2.0)
@@ -2299,8 +2299,8 @@ packages:
     dev: true
     optional: true
 
-  /@concurrent-world/client@4.2.11:
-    resolution: {integrity: sha512-jHFGoZe0v9UnQTwir6j6e18JziCNzU5mtcRDGLSTexEwnhvWPSnIxBBEAbaFAqw608EoMszk+gCfe5Tp5a7wbw==}
+  /@concurrent-world/client@4.2.12:
+    resolution: {integrity: sha512-nWVRJHJpPU41vfA5pgml7FEE7SCczOblz6+EjYgHc/6+P2o7OjJFTL9rsv2D/B0tY1PsAal4kOEnXe2GCSM7OQ==}
     dependencies:
       elliptic: 6.5.4
       ethers: 6.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@concurrent-world/client':
-    specifier: ^4.2.9
-    version: 4.2.9
+    specifier: ^4.2.10
+    version: 4.2.10
   '@emotion/react':
     specifier: ^11.10.5
     version: 11.10.5(@babel/core@7.21.8)(@types/react@18.0.26)(react@18.2.0)
@@ -2299,8 +2299,8 @@ packages:
     dev: true
     optional: true
 
-  /@concurrent-world/client@4.2.9:
-    resolution: {integrity: sha512-kHoSEcNQRh0w2mbOKA2aIiPP4wAPUxbt5CXI7snAZFD8qj0LyLN+S+aOaDleWBDGabb4B+S9ybuy6DclF9fX3w==}
+  /@concurrent-world/client@4.2.10:
+    resolution: {integrity: sha512-490fsVlVyYyPoznXPloV7R77xUXGgL47vLC9dVoACbu9khxTnq82hgjNJ3qc7icjz8KtUpYkPAGS03b79lgcyw==}
     dependencies:
       elliptic: 6.5.4
       ethers: 6.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@concurrent-world/client':
-    specifier: ^4.2.10
-    version: 4.2.10
+    specifier: ^4.2.11
+    version: 4.2.11
   '@emotion/react':
     specifier: ^11.10.5
     version: 11.10.5(@babel/core@7.21.8)(@types/react@18.0.26)(react@18.2.0)
@@ -2299,8 +2299,8 @@ packages:
     dev: true
     optional: true
 
-  /@concurrent-world/client@4.2.10:
-    resolution: {integrity: sha512-490fsVlVyYyPoznXPloV7R77xUXGgL47vLC9dVoACbu9khxTnq82hgjNJ3qc7icjz8KtUpYkPAGS03b79lgcyw==}
+  /@concurrent-world/client@4.2.11:
+    resolution: {integrity: sha512-jHFGoZe0v9UnQTwir6j6e18JziCNzU5mtcRDGLSTexEwnhvWPSnIxBBEAbaFAqw608EoMszk+gCfe5Tp5a7wbw==}
     dependencies:
       elliptic: 6.5.4
       ethers: 6.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@concurrent-world/client':
-    specifier: ^4.2.8
-    version: 4.2.8
+    specifier: ^4.2.9
+    version: 4.2.9
   '@emotion/react':
     specifier: ^11.10.5
     version: 11.10.5(@babel/core@7.21.8)(@types/react@18.0.26)(react@18.2.0)
@@ -2299,8 +2299,8 @@ packages:
     dev: true
     optional: true
 
-  /@concurrent-world/client@4.2.8:
-    resolution: {integrity: sha512-iXoFOFga/Kul3ONc0wkFaJ2Tgby4tQEqSWIkQRy60DnZ0B7K42Sclwn92wUU/NXI4UXzIJmFiowoJOMYPxB+7Q==}
+  /@concurrent-world/client@4.2.9:
+    resolution: {integrity: sha512-kHoSEcNQRh0w2mbOKA2aIiPP4wAPUxbt5CXI7snAZFD8qj0LyLN+S+aOaDleWBDGabb4B+S9ybuy6DclF9fX3w==}
     dependencies:
       elliptic: 6.5.4
       ethers: 6.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@concurrent-world/client':
-    specifier: ^4.2.13
-    version: 4.2.13
+    specifier: ^4.2.14
+    version: 4.2.14
   '@emotion/react':
     specifier: ^11.10.5
     version: 11.10.5(@babel/core@7.21.8)(@types/react@18.0.26)(react@18.2.0)
@@ -2299,8 +2299,8 @@ packages:
     dev: true
     optional: true
 
-  /@concurrent-world/client@4.2.13:
-    resolution: {integrity: sha512-J+JBRntFgC6HlpcpaybhcDnt6HebLw7g9zPUxV4lOyyyBzx4FuQI2PurZwriG69Nd1t24+YEWe61mz0TpzaVvA==}
+  /@concurrent-world/client@4.2.14:
+    resolution: {integrity: sha512-W1jGRI9AUA0SXSKh21xJHYf7sYeZ+/SfsH2P0hL01a9D8DkoDgtz3RMKSHJHVJKg1GMYARCLJ5btxgBETZo/EA==}
     dependencies:
       elliptic: 6.5.4
       ethers: 6.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@concurrent-world/client':
-    specifier: ^4.2.12
-    version: 4.2.12
+    specifier: ^4.2.13
+    version: 4.2.13
   '@emotion/react':
     specifier: ^11.10.5
     version: 11.10.5(@babel/core@7.21.8)(@types/react@18.0.26)(react@18.2.0)
@@ -2299,8 +2299,8 @@ packages:
     dev: true
     optional: true
 
-  /@concurrent-world/client@4.2.12:
-    resolution: {integrity: sha512-nWVRJHJpPU41vfA5pgml7FEE7SCczOblz6+EjYgHc/6+P2o7OjJFTL9rsv2D/B0tY1PsAal4kOEnXe2GCSM7OQ==}
+  /@concurrent-world/client@4.2.13:
+    resolution: {integrity: sha512-J+JBRntFgC6HlpcpaybhcDnt6HebLw7g9zPUxV4lOyyyBzx4FuQI2PurZwriG69Nd1t24+YEWe61mz0TpzaVvA==}
     dependencies:
       elliptic: 6.5.4
       ethers: 6.11.1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,10 +101,11 @@ function App(): JSX.Element {
                             m &&
                                 client?.api.getCharacter<ProfileSchema>(a.author, Schemas.profile).then((c) => {
                                     playNotificationRef.current()
+                                    const profile = c?.[0].payload.body
                                     enqueueSnackbar(
                                         <Box display="flex" flexDirection="column">
                                             <Typography>
-                                                {c?.payload.body.username ?? 'anonymous'} replied to your message:{' '}
+                                                {profile?.username ?? 'anonymous'} replied to your message:{' '}
                                             </Typography>
                                             <MarkdownRendererLite
                                                 messagebody={m.payload.body.body as string}
@@ -123,10 +124,11 @@ function App(): JSX.Element {
                         m &&
                             client?.api.getCharacter<ProfileSchema>(a.author, Schemas.profile).then((c) => {
                                 playNotificationRef.current()
+                                const profile = c?.[0].payload.body
                                 enqueueSnackbar(
                                     <Box display="flex" flexDirection="column">
                                         <Typography>
-                                            {c?.payload.body.username ?? 'anonymous'} rerouted to your message:{' '}
+                                            {profile?.username ?? 'anonymous'} rerouted to your message:{' '}
                                         </Typography>
                                         <MarkdownRendererLite
                                             messagebody={m.payload.body.body as string}
@@ -145,9 +147,10 @@ function App(): JSX.Element {
                         m &&
                             client.api.getCharacter<ProfileSchema>(a.author, Schemas.profile).then((c) => {
                                 playNotificationRef.current()
+                                const profile = c?.[0].payload.body
                                 enqueueSnackbar(
                                     <Box display="flex" flexDirection="column">
-                                        <Typography>{c?.payload.body.username ?? 'anonymous'} favorited</Typography>
+                                        <Typography>{profile?.username ?? 'anonymous'} favorited</Typography>
                                         <MarkdownRendererLite
                                             messagebody={m.payload.body.body as string}
                                             emojiDict={m.payload.body.emojis ?? {}}
@@ -166,10 +169,11 @@ function App(): JSX.Element {
                         m &&
                             client.api.getCharacter<ProfileSchema>(a.author, Schemas.profile).then((c) => {
                                 playNotificationRef.current()
+                                const profile = c?.[0].payload.body
                                 enqueueSnackbar(
                                     <Box display="flex" flexDirection="column">
                                         <Typography>
-                                            {c?.payload.body.username ?? 'anonymous'} reacted{' '}
+                                            {profile?.username ?? 'anonymous'} reacted{' '}
                                             <img src={a.payload.body.imageUrl as string} style={{ height: '1em' }} />
                                         </Typography>
                                         <MarkdownRendererLite
@@ -188,9 +192,10 @@ function App(): JSX.Element {
                         m &&
                             client.api.getCharacter<ProfileSchema>(a.author, Schemas.profile).then((c) => {
                                 playNotificationRef.current()
+                                const profile = c?.[0].payload.body
                                 enqueueSnackbar(
                                     <Box display="flex" flexDirection="column">
-                                        {c?.payload.body.username ?? 'anonymous'} mentioned you:{' '}
+                                        {profile?.username ?? 'anonymous'} mentioned you:{' '}
                                         <MarkdownRendererLite
                                             messagebody={m.payload.body.body as string}
                                             emojiDict={m.payload.body.emojis ?? {}}

--- a/src/components/ContentWithCCAvatar.tsx
+++ b/src/components/ContentWithCCAvatar.tsx
@@ -3,15 +3,11 @@ import { Box, IconButton, ListItem, Paper, type SxProps, Tooltip } from '@mui/ma
 import { UserProfileCard } from './UserProfileCard'
 import { Link as routerLink } from 'react-router-dom'
 import { CCAvatar } from './ui/CCAvatar'
+import { type ProfileOverride } from '@concurrent-world/client/dist/types/model/core'
 
 export interface ContentWithCCAvatarProps {
     author?: User
-    profileOverride?: {
-        username?: string
-        avatar?: string
-        description?: string
-        link?: string
-    }
+    profileOverride?: ProfileOverride
     children?: JSX.Element | Array<JSX.Element | undefined>
     sx?: SxProps
 }
@@ -62,6 +58,7 @@ export const ContentWithCCAvatar = (props: ContentWithCCAvatarProps): JSX.Elemen
                         avatarURL={props.author?.profile?.payload.body.avatar}
                         avatarOverride={props.profileOverride?.avatar}
                         identiconSource={props.author?.ccid ?? ''}
+                        characterOverride={props.profileOverride?.characterID}
                         sx={{
                             width: { xs: '38px', sm: '48px' },
                             height: { xs: '38px', sm: '48px' }

--- a/src/components/Devtool/CCComposer.tsx
+++ b/src/components/Devtool/CCComposer.tsx
@@ -126,7 +126,8 @@ export const CCComposer = forwardRef<HTMLDivElement>((props, ref): JSX.Element =
                         if (cctype === 'character') {
                             if (!client.ccid) return
                             client.api.getCharacter(client.ccid, schemaURLDraft).then((e) => {
-                                setCharacter(e)
+                                if (!e || e.length === 0) return
+                                setCharacter(e[0])
                                 setSchemaURL(schemaURLDraft)
                             })
                         } else {

--- a/src/components/Message/DummyMessageView.tsx
+++ b/src/components/Message/DummyMessageView.tsx
@@ -10,6 +10,7 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import RepeatIcon from '@mui/icons-material/Repeat'
 import ReplyIcon from '@mui/icons-material/Reply'
 import { TimeDiff } from '../ui/TimeDiff'
+import { SubprofileBadge } from '../ui/SubprofileBadge'
 
 export interface DummyMessageViewProps {
     message?: SimpleNoteSchema | ReplyMessageSchema
@@ -17,6 +18,8 @@ export interface DummyMessageViewProps {
     userCCID?: string
     timestamp?: JSX.Element
     hideActions?: boolean
+    onAvatarClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
+    subprofileID?: string
 }
 
 export const DummyMessageView = (props: DummyMessageViewProps): JSX.Element => {
@@ -38,16 +41,31 @@ export const DummyMessageView = (props: DummyMessageViewProps): JSX.Element => {
                             height: { xs: '38px', sm: '48px' },
                             mt: { xs: '3px', sm: '5px' }
                         }}
+                        onClick={(e) => {
+                            props.onAvatarClick?.(e)
+                        }}
                     >
-                        <CCAvatar
-                            alt={props.user?.username ?? 'Unknown'}
-                            avatarURL={props.user?.avatar}
-                            identiconSource={props.userCCID ?? 'concurrent'}
-                            sx={{
-                                width: { xs: '38px', sm: '48px' },
-                                height: { xs: '38px', sm: '48px' }
-                            }}
-                        />
+                        {props.subprofileID ? (
+                            <SubprofileBadge
+                                characterID={props.subprofileID}
+                                authorCCID={props.userCCID ?? ''}
+                                sx={{
+                                    width: { xs: '38px', sm: '48px' },
+                                    height: { xs: '38px', sm: '48px' },
+                                    mt: { xs: '3px', sm: '5px' }
+                                }}
+                            />
+                        ) : (
+                            <CCAvatar
+                                alt={props.user?.username ?? 'Unknown'}
+                                avatarURL={props.user?.avatar}
+                                identiconSource={props.userCCID ?? 'concurrent'}
+                                sx={{
+                                    width: { xs: '38px', sm: '48px' },
+                                    height: { xs: '38px', sm: '48px' }
+                                }}
+                            />
+                        )}
                     </IconButton>
                     <Box
                         sx={{

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Typography, useTheme, Link } from '@mui/material'
+import { Box, Button, Typography, useTheme, Link, Divider } from '@mui/material'
 
 import { CCAvatar } from '../components/ui/CCAvatar'
 import { WatchButton } from '../components/WatchButton'
@@ -8,17 +8,21 @@ import { MarkdownRenderer } from '../components/ui/MarkdownRenderer'
 import { Link as NavLink } from 'react-router-dom'
 
 import { useEffect, useState } from 'react'
-import { type User } from '@concurrent-world/client'
+import { type CoreCharacter, type User } from '@concurrent-world/client'
 import { useApi } from '../context/api'
 import { CCDrawer } from './ui/CCDrawer'
 import { AckList } from '../components/AckList'
 import { CCWallpaper } from './ui/CCWallpaper'
 import { useTranslation } from 'react-i18next'
+import { SubprofileBadge } from './ui/SubprofileBadge'
+import { ProfileProperties } from './ui/ProfileProperties'
 
 export interface ProfileProps {
     user: User
     id?: string
     guest?: boolean
+    onSubCharacterClicked?: (characterID: string) => void
+    overrideSubCharacterID?: string
 }
 
 type detail = 'none' | 'ack' | 'acker'
@@ -32,6 +36,8 @@ export function Profile(props: ProfileProps): JSX.Element {
     const [detailMode, setDetailMode] = useState<detail>('none')
     const [ackingUsers, setAckingUsers] = useState<User[]>([])
     const [ackerUsers, setAckerUsers] = useState<User[]>([])
+
+    const [subCharacter, setSubCharacter] = useState<CoreCharacter<any> | null>(null)
 
     const { t } = useTranslation('', { keyPrefix: 'common' })
 
@@ -50,6 +56,16 @@ export function Profile(props: ProfileProps): JSX.Element {
             unmounted = true
         }
     }, [props.user])
+
+    useEffect(() => {
+        if (!client || !props.overrideSubCharacterID) {
+            setSubCharacter(null)
+            return
+        }
+        client.api.getCharacterByID(props.overrideSubCharacterID, props.user.ccid).then((character) => {
+            setSubCharacter(character ?? null)
+        })
+    }, [client, props.overrideSubCharacterID, props.user.ccid])
 
     return (
         <>
@@ -72,20 +88,36 @@ export function Profile(props: ProfileProps): JSX.Element {
                     <CCAvatar
                         alt={props.user.profile?.payload.body.username}
                         avatarURL={props.user.profile?.payload.body.avatar}
+                        avatarOverride={subCharacter ? subCharacter.payload.body.avatar : undefined}
                         identiconSource={props.user.ccid}
                         sx={{
                             width: '100px',
                             height: '100px'
+                        }}
+                        onBadgeClick={() => {
+                            props.onSubCharacterClicked?.('')
                         }}
                     />
                 </Box>
                 <Box
                     display="flex"
                     alignItems="center"
-                    justifyContent="flex-end"
+                    justifyContent="space-between"
                     visibility={props.guest ? 'hidden' : 'visible'}
                     gap={1}
                 >
+                    <Box ml="110px" display="flex" gap={1}>
+                        {props.user.profile?.payload.body.subprofiles?.map((id, _) => (
+                            <SubprofileBadge
+                                key={id}
+                                characterID={id}
+                                authorCCID={props.user.ccid}
+                                onClick={() => {
+                                    props.onSubCharacterClicked?.(id)
+                                }}
+                            />
+                        ))}
+                    </Box>
                     {!isSelf ? (
                         <>
                             <AckButton user={props.user} />
@@ -109,7 +141,9 @@ export function Profile(props: ProfileProps): JSX.Element {
                             fontSize: { xs: '1.2rem', sm: '1.5rem', md: '1.5rem' }
                         }}
                     >
-                        {props.user.profile?.payload.body.username || 'anonymous'}
+                        {subCharacter?.payload.body.username ??
+                            props.user.profile?.payload.body.username ??
+                            'anonymous'}
                     </Typography>
                     <Typography variant="caption">{props.user.ccid}</Typography>
                 </Box>
@@ -119,7 +153,12 @@ export function Profile(props: ProfileProps): JSX.Element {
                         flexFlow: 'column'
                     }}
                 >
-                    <MarkdownRenderer messagebody={props.user.profile?.payload.body.description ?? ''} emojiDict={{}} />
+                    <MarkdownRenderer
+                        messagebody={
+                            subCharacter?.payload.body.description ?? props.user.profile?.payload.body.description ?? ''
+                        }
+                        emojiDict={{}}
+                    />
                 </Box>
                 <Box>
                     <Typography variant="caption">
@@ -147,6 +186,13 @@ export function Profile(props: ProfileProps): JSX.Element {
                     </Typography>
                 </Box>
             </Box>
+            {subCharacter && (
+                <>
+                    <Divider sx={{ mb: 1 }} />
+                    <ProfileProperties showCreateLink character={subCharacter} />
+                    <Divider />
+                </>
+            )}
             <CCDrawer
                 open={detailMode !== 'none'}
                 onClose={() => {

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -34,7 +34,7 @@ export function ProfileEditor(props: ProfileEditorProps): JSX.Element {
                 props.onSubmit?.(data)
             })
         } else {
-            client.updateProfile(props.id, username, description, avatar, banner).then((data) => {
+            client.updateProfile(props.id, { username, description, avatar, banner }).then((data) => {
                 console.log(data)
                 props.onSubmit?.(data)
             })

--- a/src/components/Settings/Profile.tsx
+++ b/src/components/Settings/Profile.tsx
@@ -1,14 +1,53 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Button, ListItemIcon, ListItemText, MenuItem, TextField, Typography } from '@mui/material'
 import { ProfileEditor } from '../ProfileEditor'
 import { useApi } from '../../context/api'
 import { useSnackbar } from 'notistack'
 import { useTranslation } from 'react-i18next'
+import { type CoreCharacter, type Schema } from '@concurrent-world/client'
+import { useEffect, useState } from 'react'
+import { CCDrawer } from '../ui/CCDrawer'
+import { CCEditor } from '../ui/cceditor'
+import { SubProfileCard } from '../SubProfileCard'
+
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import EditIcon from '@mui/icons-material/Edit'
 
 export const ProfileSettings = (): JSX.Element => {
     const client = useApi()
     const { enqueueSnackbar } = useSnackbar()
 
     const { t } = useTranslation('', { keyPrefix: 'settings.profile' })
+
+    const [allCharacters, setAllCharacters] = useState<Array<CoreCharacter<any>>>([])
+    const [openCharacterEditor, setOpenCharacterEditor] = useState(false)
+
+    const [schemaURLDraft, setSchemaURLDraft] = useState<string>('')
+    const [schemaURL, setSchemaURL] = useState<any>(null)
+    const [editingCharacter, setEditingCharacter] = useState<CoreCharacter<any> | null>(null)
+
+    useEffect(() => {
+        if (!client) return
+        client.api.getCharacter(client.ccid).then((characters) => {
+            setAllCharacters(
+                (characters ?? []).filter(
+                    (c) => c.id !== client.user?.profile?.id && c.id !== client.user?.userstreams?.id
+                )
+            )
+        })
+    }, [client])
+
+    useEffect(() => {
+        let isMounted = true
+        const timer = setTimeout(() => {
+            if (isMounted) {
+                setSchemaURL(schemaURLDraft)
+            }
+        }, 300)
+        return () => {
+            isMounted = false
+            clearTimeout(timer)
+        }
+    }, [schemaURLDraft])
 
     return (
         <Box
@@ -18,25 +57,127 @@ export const ProfileSettings = (): JSX.Element => {
                 gap: '30px'
             }}
         >
-            <Box>
-                <Typography variant="h3">{t('title')}</Typography>
-                <Box
-                    sx={{
-                        width: '100%',
-                        borderRadius: 1,
-                        overflow: 'hidden',
-                        mb: 1
+            <Typography variant="h3">{t('title')}</Typography>
+            <Box
+                sx={{
+                    width: '100%',
+                    borderRadius: 1,
+                    overflow: 'hidden',
+                    mb: 1
+                }}
+            >
+                <ProfileEditor
+                    id={client?.user?.profile?.id}
+                    initial={client?.user?.profile?.payload.body}
+                    onSubmit={(_profile) => {
+                        enqueueSnackbar(t('updated'), { variant: 'success' })
+                    }}
+                />
+            </Box>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'center'
+                }}
+            >
+                <Typography variant="h3">サブプロフィール</Typography>
+                <Button
+                    onClick={() => {
+                        setOpenCharacterEditor(true)
                     }}
                 >
-                    <ProfileEditor
-                        id={client?.user?.profile?.id}
-                        initial={client?.user?.profile?.payload.body}
-                        onSubmit={(_profile) => {
-                            enqueueSnackbar(t('updated'), { variant: 'success' })
-                        }}
-                    />
-                </Box>
+                    新規
+                </Button>
             </Box>
+            {allCharacters.map((character) => (
+                <SubProfileCard
+                    key={character.id}
+                    character={character}
+                    additionalMenuItems={
+                        <>
+                            <MenuItem
+                                onClick={() => {
+                                    setEditingCharacter(character)
+                                }}
+                            >
+                                <ListItemIcon>
+                                    <EditIcon sx={{ color: 'text.primary' }} />
+                                </ListItemIcon>
+                                <ListItemText>編集</ListItemText>
+                            </MenuItem>
+                            <MenuItem
+                                onClick={() => {
+                                    client.api.deleteCharacter(character.id).then((_) => {
+                                        console.log('deleted')
+                                    })
+                                }}
+                            >
+                                <ListItemIcon>
+                                    <DeleteForeverIcon sx={{ color: 'error.main' }} />
+                                </ListItemIcon>
+                                <ListItemText>削除</ListItemText>
+                            </MenuItem>
+                        </>
+                    }
+                />
+            ))}
+            <CCDrawer
+                open={openCharacterEditor || editingCharacter !== null}
+                onClose={() => {
+                    setOpenCharacterEditor(false)
+                    setEditingCharacter(null)
+                }}
+            >
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '30px',
+                        p: 3
+                    }}
+                >
+                    {openCharacterEditor && (
+                        <>
+                            <Typography variant="h3">新規サブプロフィール</Typography>
+                            <TextField
+                                label="テンプレートのURL"
+                                value={schemaURLDraft}
+                                onChange={(e) => {
+                                    setSchemaURLDraft(e.target.value)
+                                }}
+                            />
+                            <CCEditor
+                                schemaURL={schemaURL}
+                                onSubmit={(e) => {
+                                    console.log(e)
+                                    client.api.upsertCharacter(schemaURL as Schema, e).then((_) => {
+                                        setOpenCharacterEditor(false)
+                                    })
+                                }}
+                            />
+                        </>
+                    )}
+                    {editingCharacter && (
+                        <>
+                            <Typography variant="h3">サブプロフィールの編集</Typography>
+                            <CCEditor
+                                schemaURL={editingCharacter.schema}
+                                init={editingCharacter.payload.body}
+                                onSubmit={(e) => {
+                                    console.log(e)
+                                    client.api
+                                        .upsertCharacter(editingCharacter.schema, e, editingCharacter.id)
+                                        .then((_) => {
+                                            setEditingCharacter(null)
+                                        })
+                                }}
+                            />
+                        </>
+                    )}
+                </Box>
+            </CCDrawer>
         </Box>
     )
 }

--- a/src/components/Settings/Profile.tsx
+++ b/src/components/Settings/Profile.tsx
@@ -13,12 +13,16 @@ import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
 import PublishIcon from '@mui/icons-material/Publish'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import EditIcon from '@mui/icons-material/Edit'
+import { useLocation } from 'react-router-dom'
 
 export const ProfileSettings = (): JSX.Element => {
     const client = useApi()
     const { enqueueSnackbar } = useSnackbar()
 
     const { t } = useTranslation('', { keyPrefix: 'settings.profile' })
+
+    const path = useLocation()
+    const hash = path.hash.replace('#', '')
 
     const [allCharacters, setAllCharacters] = useState<Array<CoreCharacter<any>>>([])
     const [openCharacterEditor, setOpenCharacterEditor] = useState(false)
@@ -59,6 +63,13 @@ export const ProfileSettings = (): JSX.Element => {
             clearTimeout(timer)
         }
     }, [schemaURLDraft])
+
+    useEffect(() => {
+        if (hash) {
+            setSchemaURLDraft(hash)
+            setOpenCharacterEditor(true)
+        }
+    }, [hash])
 
     useEffect(() => {
         if (modified) {
@@ -229,6 +240,7 @@ export const ProfileSettings = (): JSX.Element => {
                                     console.log(e)
                                     client.api.upsertCharacter(schemaURL as Schema, e).then((_) => {
                                         setOpenCharacterEditor(false)
+                                        load()
                                     })
                                 }}
                             />
@@ -246,6 +258,7 @@ export const ProfileSettings = (): JSX.Element => {
                                         .upsertCharacter(editingCharacter.schema, e, editingCharacter.id)
                                         .then((_) => {
                                             setEditingCharacter(null)
+                                            load()
                                         })
                                 }}
                             />

--- a/src/components/SubProfileCard.tsx
+++ b/src/components/SubProfileCard.tsx
@@ -3,9 +3,10 @@ import { Box, IconButton, Menu, Paper, Typography } from '@mui/material'
 import { CCWallpaper } from './ui/CCWallpaper'
 import { CCAvatar } from './ui/CCAvatar'
 import { MarkdownRendererLite } from './ui/MarkdownRendererLite'
-import { useEffect, useMemo, useState } from 'react'
+import { useState } from 'react'
 
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
+import { ProfileProperties } from './ui/ProfileProperties'
 
 export interface SubProfileCardProps {
     character: CoreCharacter<any>
@@ -13,45 +14,10 @@ export interface SubProfileCardProps {
     children?: JSX.Element | JSX.Element[]
 }
 
-const defaultProperties = ['username', 'avatar', 'description', 'banner', 'links']
-
 export const SubProfileCard = (props: SubProfileCardProps): JSX.Element => {
     const isProfile = 'username' in props.character.payload.body && 'avatar' in props.character.payload.body
-    const [schema, setSchema] = useState<any>()
 
     const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null)
-
-    const properties = useMemo(() => {
-        if (!schema) return []
-        const specialProperties = schema.properties
-        for (const def of defaultProperties) {
-            delete specialProperties[def]
-        }
-
-        const properties = []
-        for (const key in specialProperties) {
-            if (specialProperties[key].type !== 'string') continue
-            properties.push({
-                key,
-                title: specialProperties[key].title,
-                description: specialProperties[key].description
-            })
-        }
-        return properties
-    }, [schema])
-
-    useEffect(() => {
-        let unmounted = false
-        fetch(props.character.schema)
-            .then((res) => res.json())
-            .then((data) => {
-                if (unmounted) return
-                setSchema(data)
-            })
-        return () => {
-            unmounted = true
-        }
-    }, [])
 
     return (
         <Paper variant="outlined">
@@ -137,19 +103,7 @@ export const SubProfileCard = (props: SubProfileCardProps): JSX.Element => {
                             emojiDict={{}}
                         />
                     </Box>
-                    <Box>
-                        {properties.map(
-                            (property, index) =>
-                                property.key in props.character.payload.body && (
-                                    <Box key={index} px={1} mb={1}>
-                                        {/* <Typography variant="h3">{property.title}</Typography> */}
-                                        <Typography variant="body1">
-                                            {property.description}: {props.character.payload.body[property.key]}
-                                        </Typography>
-                                    </Box>
-                                )
-                        )}
-                    </Box>
+                    <ProfileProperties character={props.character} />
                 </>
             ) : (
                 <>

--- a/src/components/SubProfileCard.tsx
+++ b/src/components/SubProfileCard.tsx
@@ -10,6 +10,7 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 export interface SubProfileCardProps {
     character: CoreCharacter<any>
     additionalMenuItems?: JSX.Element | JSX.Element[]
+    children?: JSX.Element | JSX.Element[]
 }
 
 const defaultProperties = ['username', 'avatar', 'description', 'banner', 'links']
@@ -108,7 +109,7 @@ export const SubProfileCard = (props: SubProfileCardProps): JSX.Element => {
                         px={1}
                         mb={1}
                     >
-                        未掲載
+                        {props.children}
                     </Box>
                     <Box
                         display="flex"

--- a/src/components/SubProfileCard.tsx
+++ b/src/components/SubProfileCard.tsx
@@ -1,0 +1,169 @@
+import { type CoreCharacter } from '@concurrent-world/client'
+import { Box, IconButton, Menu, Paper, Typography } from '@mui/material'
+import { CCWallpaper } from './ui/CCWallpaper'
+import { CCAvatar } from './ui/CCAvatar'
+import { MarkdownRendererLite } from './ui/MarkdownRendererLite'
+import { useEffect, useMemo, useState } from 'react'
+
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
+
+export interface SubProfileCardProps {
+    character: CoreCharacter<any>
+    additionalMenuItems?: JSX.Element | JSX.Element[]
+}
+
+const defaultProperties = ['username', 'avatar', 'description', 'banner', 'links']
+
+export const SubProfileCard = (props: SubProfileCardProps): JSX.Element => {
+    const isProfile = 'username' in props.character.payload.body && 'avatar' in props.character.payload.body
+    const [schema, setSchema] = useState<any>()
+
+    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null)
+
+    const properties = useMemo(() => {
+        if (!schema) return []
+        const specialProperties = schema.properties
+        for (const def of defaultProperties) {
+            delete specialProperties[def]
+        }
+
+        const properties = []
+        for (const key in specialProperties) {
+            if (specialProperties[key].type !== 'string') continue
+            properties.push({
+                key,
+                title: specialProperties[key].title,
+                description: specialProperties[key].description
+            })
+        }
+        return properties
+    }, [schema])
+
+    useEffect(() => {
+        let unmounted = false
+        fetch(props.character.schema)
+            .then((res) => res.json())
+            .then((data) => {
+                if (unmounted) return
+                setSchema(data)
+            })
+        return () => {
+            unmounted = true
+        }
+    }, [])
+
+    return (
+        <Paper variant="outlined">
+            {isProfile ? (
+                <>
+                    <CCWallpaper
+                        sx={{
+                            height: '80px',
+                            position: 'relative'
+                        }}
+                        override={props.character.payload.body.banner}
+                    >
+                        {props.additionalMenuItems && (
+                            <IconButton
+                                sx={{
+                                    color: 'text.disabled',
+                                    position: 'absolute',
+                                    right: 2,
+                                    top: 2
+                                }}
+                                onClick={(e) => {
+                                    setMenuAnchor(e.currentTarget)
+                                }}
+                            >
+                                <MoreHorizIcon sx={{ fontSize: '80%' }} />
+                            </IconButton>
+                        )}
+                    </CCWallpaper>
+                    <Box position="relative" height={0}>
+                        <Box
+                            position="relative"
+                            sx={{
+                                top: '-30px',
+                                left: '10px'
+                            }}
+                        >
+                            <CCAvatar
+                                alt={props.character.payload.body.username}
+                                avatarURL={props.character.payload.body.avatar}
+                                identiconSource={props.character.payload.body.username}
+                                sx={{
+                                    width: '60px',
+                                    height: '60px'
+                                }}
+                            />
+                        </Box>
+                    </Box>
+                    <Box
+                        display="flex"
+                        flexDirection="row"
+                        justifyContent="flex-end"
+                        alignItems="center"
+                        height="40px"
+                        gap={1}
+                        px={1}
+                        mb={1}
+                    >
+                        未掲載
+                    </Box>
+                    <Box
+                        display="flex"
+                        flexDirection="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                        gap={1}
+                        px={1}
+                        mb={1}
+                    >
+                        <Typography variant="h2">{props.character.payload.body.username}</Typography>
+                        <Box />
+                    </Box>
+                    <Box
+                        sx={{
+                            maxHeight: '100px',
+                            overflowX: 'hidden',
+                            overflowY: 'auto',
+                            px: 1,
+                            mb: 1
+                        }}
+                    >
+                        <MarkdownRendererLite
+                            messagebody={props.character.payload.body.description ?? ''}
+                            emojiDict={{}}
+                        />
+                    </Box>
+                    <Box>
+                        {properties.map(
+                            (property, index) =>
+                                property.key in props.character.payload.body && (
+                                    <Box key={index} px={1} mb={1}>
+                                        {/* <Typography variant="h3">{property.title}</Typography> */}
+                                        <Typography variant="body1">
+                                            {property.description}: {props.character.payload.body[property.key]}
+                                        </Typography>
+                                    </Box>
+                                )
+                        )}
+                    </Box>
+                </>
+            ) : (
+                <>
+                    <Typography variant="h2">Not a profile</Typography>
+                </>
+            )}
+            <Menu
+                anchorEl={menuAnchor}
+                open={Boolean(menuAnchor)}
+                onClose={() => {
+                    setMenuAnchor(null)
+                }}
+            >
+                {props.additionalMenuItems}
+            </Menu>
+        </Paper>
+    )
+}

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -1,4 +1,4 @@
-import { type User } from '@concurrent-world/client'
+import { type CoreCharacter, type ProfileSchema, type User } from '@concurrent-world/client'
 import { Box, Chip, Typography } from '@mui/material'
 import { CCAvatar } from './ui/CCAvatar'
 import { useApi } from '../context/api'
@@ -9,7 +9,8 @@ import { MarkdownRenderer } from './ui/MarkdownRenderer'
 import { CCWallpaper } from './ui/CCWallpaper'
 
 export interface UserProfileCardProps {
-    user: User | undefined
+    user?: User
+    character?: CoreCharacter<ProfileSchema>
 }
 
 export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
@@ -17,7 +18,9 @@ export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
     const isSelf = props.user?.ccid === client?.ccid
     const { enqueueSnackbar } = useSnackbar()
 
-    if (!props.user) return <></>
+    const character = props.user?.profile ?? props.character
+
+    if (!character) return <></>
 
     return (
         <Box display="flex" flexDirection="column" maxWidth="500px">
@@ -25,7 +28,7 @@ export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
                 sx={{
                     height: '80px'
                 }}
-                override={props.user.profile?.payload.body.banner}
+                override={character.payload.body.banner}
             />
             <Box position="relative" height={0}>
                 <Box
@@ -36,9 +39,9 @@ export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
                     }}
                 >
                     <CCAvatar
-                        alt={props.user.profile?.payload.body.username}
-                        avatarURL={props.user.profile?.payload.body.avatar}
-                        identiconSource={props.user.ccid ?? ''}
+                        alt={character.payload.body.username}
+                        avatarURL={character.payload.body.avatar}
+                        identiconSource={character.author}
                         sx={{
                             width: '60px',
                             height: '60px'
@@ -56,7 +59,7 @@ export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
                 px={1}
                 mb={1}
             >
-                {!isSelf && (
+                {!isSelf && props.user && (
                     <>
                         <AckButton user={props.user} />
                     </>
@@ -71,10 +74,10 @@ export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
                 px={1}
                 mb={1}
             >
-                <Typography variant="h2">{props.user.profile?.payload.body.username}</Typography>
+                <Typography variant="h2">{character.payload.body.username}</Typography>
                 <Chip
                     size="small"
-                    label={`${props.user.ccid.slice(0, 9)}...`}
+                    label={`${character.author.slice(0, 9)}...`}
                     deleteIcon={<ContentPasteIcon />}
                     onDelete={() => {
                         navigator.clipboard.writeText(props.user?.ccid ?? '')
@@ -91,7 +94,7 @@ export const UserProfileCard = (props: UserProfileCardProps): JSX.Element => {
                     mb: 1
                 }}
             >
-                <MarkdownRenderer messagebody={props.user.profile?.payload.body.description ?? ''} emojiDict={{}} />
+                <MarkdownRenderer messagebody={character.payload.body.description ?? ''} emojiDict={{}} />
             </Box>
         </Box>
     )

--- a/src/components/ui/CCAvatar.tsx
+++ b/src/components/ui/CCAvatar.tsx
@@ -1,5 +1,8 @@
 import { Avatar, Badge, type SxProps } from '@mui/material'
 import BoringAvatar from 'boring-avatars'
+import { useApi } from '../../context/api'
+import { useEffect, useState } from 'react'
+import { type CoreCharacter } from '@concurrent-world/client'
 
 export interface CCAvatarProps {
     sx?: SxProps
@@ -7,10 +10,21 @@ export interface CCAvatarProps {
     avatarURL?: string
     avatarOverride?: string
     identiconSource?: string
+    characterOverride?: string
     onBadgeClick?: () => void
 }
 
 export const CCAvatar = (props: CCAvatarProps): JSX.Element => {
+    const client = useApi()
+    const [characterOverride, setCharacterOverride] = useState<CoreCharacter<any> | undefined>(undefined)
+
+    useEffect(() => {
+        if (!(client && props.characterOverride && props.identiconSource)) return
+        client.api.getCharacterByID(props.characterOverride, props.identiconSource).then((character) => {
+            setCharacterOverride(character ?? undefined)
+        })
+    }, [props.characterOverride])
+
     return (
         <Badge
             overlap="circular"
@@ -19,7 +33,7 @@ export const CCAvatar = (props: CCAvatarProps): JSX.Element => {
                 horizontal: 'right'
             }}
             badgeContent={
-                props.avatarOverride && (
+                (characterOverride?.payload.body.avatar || props.avatarOverride) && (
                     <CCAvatar
                         sx={{
                             width: 24,
@@ -34,7 +48,7 @@ export const CCAvatar = (props: CCAvatarProps): JSX.Element => {
         >
             <Avatar
                 alt={props.alt}
-                src={props.avatarOverride || props.avatarURL}
+                src={characterOverride?.payload.body.avatar ?? props.avatarOverride ?? props.avatarURL}
                 sx={{
                     ...props.sx,
                     borderRadius: 1

--- a/src/components/ui/CCAvatar.tsx
+++ b/src/components/ui/CCAvatar.tsx
@@ -7,6 +7,7 @@ export interface CCAvatarProps {
     avatarURL?: string
     avatarOverride?: string
     identiconSource?: string
+    onBadgeClick?: () => void
 }
 
 export const CCAvatar = (props: CCAvatarProps): JSX.Element => {
@@ -29,6 +30,7 @@ export const CCAvatar = (props: CCAvatarProps): JSX.Element => {
                     />
                 )
             }
+            onClick={() => props.onBadgeClick?.()}
         >
             <Avatar
                 alt={props.alt}

--- a/src/components/ui/ProfileProperties.tsx
+++ b/src/components/ui/ProfileProperties.tsx
@@ -1,0 +1,73 @@
+import { type CoreCharacter } from '@concurrent-world/client'
+import { Box, Link, Typography } from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+
+export interface ProfilePropertiesProps {
+    character: CoreCharacter<any>
+    showCreateLink?: boolean
+}
+
+const defaultProperties = ['username', 'avatar', 'description', 'banner', 'links']
+
+export const ProfileProperties = (props: ProfilePropertiesProps): JSX.Element => {
+    const [schema, setSchema] = useState<any>()
+
+    const properties = useMemo(() => {
+        if (!schema) return []
+        const specialProperties = schema.properties
+        for (const def of defaultProperties) {
+            delete specialProperties[def]
+        }
+
+        const properties = []
+        for (const key in specialProperties) {
+            if (specialProperties[key].type !== 'string') continue
+            properties.push({
+                key,
+                title: specialProperties[key].title,
+                description: specialProperties[key].description
+            })
+        }
+        return properties
+    }, [schema])
+
+    useEffect(() => {
+        let unmounted = false
+        fetch(props.character.schema)
+            .then((res) => res.json())
+            .then((data) => {
+                if (unmounted) return
+                setSchema(data)
+            })
+        return () => {
+            unmounted = true
+        }
+    }, [])
+
+    return (
+        <Box>
+            {properties.map(
+                (property, index) =>
+                    property.key in props.character.payload.body && (
+                        <Box key={index} px={1} mb={1}>
+                            {/* <Typography variant="h3">{property.title}</Typography> */}
+                            <Typography variant="body1">
+                                {property.description}: {props.character.payload.body[property.key]}
+                            </Typography>
+                        </Box>
+                    )
+            )}
+            {props.showCreateLink && (
+                <Box display="flex" width="100%" justifyContent="flex-end" px={1}>
+                    <Typography variant="caption">
+                        これはテンプレート「{schema?.title || '無名'}」で作成されました。
+                    </Typography>
+                    <Link variant="caption" component={RouterLink} to={`/settings/profile#${props.character.schema}`}>
+                        自分も作成する
+                    </Link>
+                </Box>
+            )}
+        </Box>
+    )
+}

--- a/src/components/ui/ProfileProperties.tsx
+++ b/src/components/ui/ProfileProperties.tsx
@@ -34,7 +34,9 @@ export const ProfileProperties = (props: ProfilePropertiesProps): JSX.Element =>
 
     useEffect(() => {
         let unmounted = false
-        fetch(props.character.schema)
+        fetch(props.character.schema, {
+            cache: 'force-cache'
+        })
             .then((res) => res.json())
             .then((data) => {
                 if (unmounted) return

--- a/src/components/ui/SubprofileBadge.tsx
+++ b/src/components/ui/SubprofileBadge.tsx
@@ -1,0 +1,41 @@
+import { type CoreCharacter } from '@concurrent-world/client'
+import { useEffect, useState } from 'react'
+import { useApi } from '../../context/api'
+import { Avatar, type SxProps, Tooltip } from '@mui/material'
+import BoringAvatar from 'boring-avatars'
+
+export interface SubprofileBadgeProps {
+    characterID: string
+    authorCCID: string
+    onClick?: (characterID: string) => void
+    sx?: SxProps
+}
+
+export function SubprofileBadge(props: SubprofileBadgeProps): JSX.Element {
+    const client = useApi()
+
+    const [character, setCharacter] = useState<CoreCharacter<any> | null>(null)
+
+    useEffect(() => {
+        client.api.getCharacterByID(props.characterID, props.authorCCID).then((character) => {
+            setCharacter(character ?? null)
+        })
+    }, [props.characterID])
+
+    return (
+        <Tooltip arrow title={character?.payload.body.username} placement="top">
+            <Avatar
+                alt={character?.payload.body.username}
+                src={character?.payload.body.avatar}
+                sx={{
+                    ...props.sx,
+                    borderRadius: 1
+                }}
+                variant="square"
+                onClick={() => props.onClick?.(props.characterID)}
+            >
+                <BoringAvatar square name={character?.payload.body.username} variant="beam" size={1000} />
+            </Avatar>
+        </Tooltip>
+    )
+}

--- a/src/context/GlobalActions.tsx
+++ b/src/context/GlobalActions.tsx
@@ -203,7 +203,10 @@ export const GlobalActionsProvider = (props: GlobalActionsProps): JSX.Element =>
         const domain = await client.api.getDomain(client.api.host)
         if (!domain) throw new Error('Domain not found')
         try {
-            const domainProfile = await client.api.getCharacter<DomainProfileSchema>(domain.ccid, Schemas.domainProfile)
+            const domainProfile = ((await client.api.getCharacter<DomainProfileSchema>(
+                domain.ccid,
+                Schemas.domainProfile
+            )) ?? [null])[0]
             if (!domainProfile) throw new Error('Domain profile not found')
             if (domainProfile.payload.body.defaultBookmarkStreams)
                 localStorage.setItem(

--- a/src/context/GlobalActions.tsx
+++ b/src/context/GlobalActions.tsx
@@ -328,9 +328,9 @@ export const GlobalActionsProvider = (props: GlobalActionsProps): JSX.Element =>
                                                 }
                                                 onSubmit={async (text, streams, options): Promise<Error | null> => {
                                                     if (mode === 'reroute') {
-                                                        await targetMessage.reroute(streams, text, options?.emojis)
+                                                        await targetMessage.reroute(streams, text, options)
                                                     } else if (mode === 'reply') {
-                                                        await targetMessage.reply(streams, text, options?.emojis)
+                                                        await targetMessage.reply(streams, text, options)
                                                     }
                                                     setMode('none')
                                                     return null
@@ -406,9 +406,9 @@ export const GlobalActionsProvider = (props: GlobalActionsProps): JSX.Element =>
                                                 }
                                                 onSubmit={async (text, streams, options): Promise<Error | null> => {
                                                     if (mode === 'reroute') {
-                                                        await targetMessage.reroute(streams, text, options?.emojis)
+                                                        await targetMessage.reroute(streams, text, options)
                                                     } else if (mode === 'reply') {
-                                                        await targetMessage.reply(streams, text, options?.emojis)
+                                                        await targetMessage.reply(streams, text, options)
                                                     }
                                                     setMode('none')
                                                     return null

--- a/src/pages/Entity.tsx
+++ b/src/pages/Entity.tsx
@@ -1,6 +1,6 @@
 import { Box, Collapse, Divider, Tab, Tabs } from '@mui/material'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import { useApi } from '../context/api'
 import { Timeline } from '../components/Timeline'
 import { type User } from '@concurrent-world/client'
@@ -20,6 +20,9 @@ export function EntityPage(): JSX.Element {
     const [showHeader, setShowHeader] = useState(false)
 
     const [tab, setTab] = useState(0)
+
+    const path = useLocation()
+    const subCharacterID = path.hash.replace('#', '')
 
     useEffect(() => {
         if (!id) return
@@ -75,7 +78,14 @@ export function EntityPage(): JSX.Element {
                 }}
                 header={
                     <>
-                        <Profile user={user} id={id} />
+                        <Profile
+                            user={user}
+                            id={id}
+                            overrideSubCharacterID={subCharacterID}
+                            onSubCharacterClicked={(id) => {
+                                window.location.hash = id
+                            }}
+                        />
                         <Tabs
                             value={tab}
                             onChange={(_, index) => {

--- a/src/pages/Explorer.tsx
+++ b/src/pages/Explorer.tsx
@@ -1,7 +1,10 @@
 import {
+    Alert,
+    AlertTitle,
     Box,
     Button,
     Checkbox,
+    Collapse,
     Divider,
     IconButton,
     Paper,
@@ -30,6 +33,7 @@ import { type StreamWithDomain } from '../model'
 import { StreamCard } from '../components/Stream/Card'
 import { UserProfileCard } from '../components/UserProfileCard'
 import { SubProfileCard } from '../components/SubProfileCard'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 
 export function Explorer(): JSX.Element {
     const { t } = useTranslation('', { keyPrefix: 'pages.explore' })
@@ -46,6 +50,8 @@ export function Explorer(): JSX.Element {
     const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
     const [tab, setTab] = useState<number>(0)
     const [profileSchema, setProfileSchema] = useState<string>(Schemas.profile)
+
+    const [openTips, setOpenTips] = useState<boolean>(false)
 
     const [characters, setCharacters] = useState<Array<CoreCharacter<any>>>([])
 
@@ -170,9 +176,16 @@ export function Explorer(): JSX.Element {
                     gap: 1
                 }}
             >
-                <Typography variant="h3" gutterBottom>
-                    {t('domains')}
-                </Typography>
+                <Box display="flex" alignItems="center" flexDirection="row">
+                    <Typography variant="h3">{t('domains')}</Typography>
+                    <IconButton
+                        onClick={() => {
+                            setOpenTips(!openTips)
+                        }}
+                    >
+                        <HelpOutlineIcon />
+                    </IconButton>
+                </Box>
                 <Box>
                     <IconButton
                         onClick={() => {
@@ -190,6 +203,13 @@ export function Explorer(): JSX.Element {
                     </IconButton>
                 </Box>
             </Box>
+            <Collapse in={openTips}>
+                <Alert severity="info">
+                    <AlertTitle>どうしてドメインごとに表示が分かれているの？</AlertTitle>
+                    コンカレントは本来ユーザーやデータがどこのサーバー(ドメイン)にあるかを意識しないでに使えるように設計されています。
+                    なのですが、現在はまだ十分な検索機能が実装されていないため、このような表示になっています。今後の進展にご期待ください。
+                </Alert>
+            </Collapse>
             <Box
                 sx={{
                     display: 'grid',

--- a/src/pages/Registration.tsx
+++ b/src/pages/Registration.tsx
@@ -71,20 +71,17 @@ export function Registration(): JSX.Element {
 
         client?.api
             .getCharacter<DomainProfileSchema>(host.ccid, Schemas.domainProfile)
-            .then((profile: CoreCharacter<DomainProfileSchema> | null | undefined) => {
+            .then((profile: Array<CoreCharacter<DomainProfileSchema>> | null | undefined) => {
                 console.log('domainprofile:', profile)
+                const domainProfile = profile?.[0]?.payload.body
                 const list = {
                     home: {
                         label: 'Home',
                         pinned: true,
-                        streams: profile?.payload.body.defaultFollowingStreams
-                            ? profile.payload.body.defaultFollowingStreams
-                            : [],
+                        streams: domainProfile?.defaultFollowingStreams ? domainProfile?.defaultFollowingStreams : [],
                         userStreams: [],
                         expanded: false,
-                        defaultPostStreams: profile?.payload.body.defaultPostStreams
-                            ? profile.payload.body.defaultPostStreams
-                            : []
+                        defaultPostStreams: domainProfile?.defaultPostStreams ? domainProfile?.defaultPostStreams : []
                     }
                 }
 


### PR DESCRIPTION
創作キャラ・組織・ゲームプロフィールなど複数の顔が持てるようにする

TODO
- [x] schemaURLからサブプロフィールを作成するUI
- [x] サブプロフィールのメインプロフィールへの紐づけ
- [x] プロフィール画面でのサブプロフィールの表示
--- ↓は別PRでもいいかも？ ---
- [x] サブプロフィールを指定した投稿時キャラクターのオーバーライド(表示)
- [x] Draftでのサブプロフィール指定UI