### PR TITLE
Fixed to use back camera for QR code login

### DIFF
--- a/src/components/ui/QRCodeReader.tsx
+++ b/src/components/ui/QRCodeReader.tsx
@@ -10,13 +10,10 @@ export default function QRCodeReader(props: { onRead: (result: string) => void }
         hints.set(DecodeHintType.TRY_HARDER, true)
         const codeReader = new BrowserQRCodeReader(hints)
 
-        BrowserQRCodeReader.listVideoInputDevices().then((list) => {
-            const currentCamera = list[0].deviceId
-            codeReader.decodeFromVideoDevice(currentCamera, videoRef.current!, function (result, _errors, _controls) {
-                if (typeof result !== 'undefined') {
-                    props.onRead(result.getText())
-                }
-            })
+        codeReader.decodeFromVideoDevice(undefined, videoRef.current!, function (result, _errors, _controls) {
+            if (typeof result !== 'undefined') {
+                props.onRead(result.getText())
+            }
         })
     }, [])
 


### PR DESCRIPTION
# 不具合の内容
QRコードログインでインカメが使われてしまう不具合の修正

# 修正内容
以下の理由から`decodeFromVideoDevice`に`deviceId`ではなく`undefined`を渡すようにしました。
・`list[*].label`からだと判定が取りづらい
(iPhoneだと言語ごとに変わってしまうのでほぼ無理？）
・そもそも初回の「カメラへのアクセス権限」ダイアログが出たときは`list[0].deviceId`が`undefined`になってる
・コンカレを見てて初回のみカメラ開けないとか無かったので問題なさそう

# その他
下記環境で動作確認済み
・Xperia 5 V (Android14)
・Pixel 8 Pro (Android14)
Chrome、FireFox

・iPhone14 (iOS 17.3.1)
Chrome、Safari

・Windows11
Chrome、FireFox

・mac os
Safari