### PR TITLE
Hide disabled subkeys

### DIFF
--- a/src/components/Settings/Identity.tsx
+++ b/src/components/Settings/Identity.tsx
@@ -1,9 +1,10 @@
-import { Alert, Box, IconButton, Menu, MenuItem } from '@mui/material'
+import { Alert, Box, IconButton, Menu, MenuItem, Switch, FormGroup, FormControlLabel } from '@mui/material'
 import Tilt from 'react-parallax-tilt'
 import { Passport } from '../theming/Passport'
 import { Suspense, lazy, useEffect, useState } from 'react'
 import { useApi } from '../../context/api'
 import { type Key } from '@concurrent-world/client/dist/types/model/core'
+import { usePreference } from '../../context/PreferenceContext'
 
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import { KeyCard } from '../ui/KeyCard'
@@ -18,12 +19,17 @@ export const IdentitySettings = (): JSX.Element => {
     const [keys, setKeys] = useState<Key[]>([])
     const [target, setTarget] = useState<string | null>(null)
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+    const [hideDisabledSubKey, setHideDisabledSubKey] = usePreference('hideDisabledSubKey')
 
     useEffect(() => {
         client.api.getKeyList().then((res) => {
             setKeys(res)
         })
     }, [])
+
+    const toggleHideDisabledSubKey = (): void => {
+        setHideDisabledSubKey(!hideDisabledSubKey)
+    }
 
     return (
         <Box
@@ -79,13 +85,28 @@ export const IdentitySettings = (): JSX.Element => {
 
             <Box
                 sx={{
+                    padding: { sm: '10px 10px' }
+                }}
+            >
+                <FormGroup>
+                    <FormControlLabel
+                        control={
+                            <Switch size="small" checked={hideDisabledSubKey} onChange={toggleHideDisabledSubKey} />
+                        }
+                        label="無効化したサブキーを非表示にする"
+                    />
+                </FormGroup>
+            </Box>
+
+            <Box
+                sx={{
                     display: 'flex',
                     flexDirection: 'column',
                     gap: 1
                 }}
             >
                 {keys
-                    .filter((key) => key.revokePayload === 'null')
+                    .filter((key) => key.revokePayload === 'null' || !hideDisabledSubKey)
                     .map((key) => (
                         <KeyCard
                             key={key.id}

--- a/src/components/Settings/Identity.tsx
+++ b/src/components/Settings/Identity.tsx
@@ -84,26 +84,28 @@ export const IdentitySettings = (): JSX.Element => {
                     gap: 1
                 }}
             >
-                {keys.map((key) => (
-                    <KeyCard
-                        key={key.id}
-                        item={key}
-                        endItem={
-                            <IconButton
-                                sx={{
-                                    width: '40px',
-                                    height: '40px'
-                                }}
-                                onClick={(event) => {
-                                    setTarget(key.id)
-                                    setAnchorEl(event.currentTarget)
-                                }}
-                            >
-                                <MoreHorizIcon />
-                            </IconButton>
-                        }
-                    />
-                ))}
+                {keys
+                    .filter((key) => key.revokePayload === 'null')
+                    .map((key) => (
+                        <KeyCard
+                            key={key.id}
+                            item={key}
+                            endItem={
+                                <IconButton
+                                    sx={{
+                                        width: '40px',
+                                        height: '40px'
+                                    }}
+                                    onClick={(event) => {
+                                        setTarget(key.id)
+                                        setAnchorEl(event.currentTarget)
+                                    }}
+                                >
+                                    <MoreHorizIcon />
+                                </IconButton>
+                            }
+                        />
+                    ))}
                 <Menu
                     anchorEl={anchorEl}
                     open={Boolean(anchorEl)}

--- a/src/context/PreferenceContext.tsx
+++ b/src/context/PreferenceContext.tsx
@@ -23,6 +23,7 @@ export interface Preference {
         volume: number
     }
     customThemes: Record<string, DeepPartial<ConcurrentTheme>>
+    hideDisabledSubKey: boolean
 }
 
 export const defaultPreference: Preference = {
@@ -56,7 +57,8 @@ export const defaultPreference: Preference = {
         notification: NotificationSound,
         volume: 50
     },
-    customThemes: {}
+    customThemes: {},
+    hideDisabledSubKey: false
 }
 
 interface PreferenceState {


### PR DESCRIPTION
# PR内容
無効化したサブキーが残ったままなので表示上だけ消す
#506 

なんかめっちゃ行数書き換わってるように見えるけど`.filter((key) => key.revokePayload === 'null')`追加しただけです

# その他
今後ツリー表示とかでいい感じになるっぽいので`KeyCard.tsx`はそのままです