### PR TITLE
#515 パンくずリスト対応

### DIFF
--- a/src/components/ui/BreadcrumbList.tsx
+++ b/src/components/ui/BreadcrumbList.tsx
@@ -3,25 +3,16 @@ import { Link as RouterLink, useLocation } from 'react-router-dom'
 import { Breadcrumbs, Link } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
+export interface BreadcrumbListProps {
+    // K: path, T: Translation key
+    pathTitles: Record<string, string>
+}
 interface BreadcrumbItem {
     path: string
     title: string
 }
 
-const pathTitles: Record<string, string> = {
-    '/settings': 'settings.title',
-    '/settings/general': 'settings.general.title',
-    '/settings/profile': 'settings.profile.title',
-    '/settings/identity': 'settings.identity.title',
-    '/settings/theme': 'settings.theme.title',
-    '/settings/sound': 'settings.sound.title',
-    '/settings/emoji': 'settings.emoji.title',
-    '/settings/media': 'settings.media.title',
-    '/settings/activitypub': 'settings.ap.title',
-    '/settings/loginqr': 'settings.qr.title'
-}
-
-export const BreadcrumbList = (): JSX.Element => {
+export const BreadcrumbList = (props: BreadcrumbListProps): JSX.Element => {
     const { t } = useTranslation()
     const currentPath = useLocation()
 
@@ -29,7 +20,7 @@ export const BreadcrumbList = (): JSX.Element => {
         .split('/')
         .reduce<BreadcrumbItem[]>((acc, path, index, paths) => {
             const currentPath = `/${paths.slice(1, index + 1).join('/')}`
-            const title = pathTitles[currentPath]
+            const title = props.pathTitles[currentPath]
             if (title) {
                 acc.push({ path: currentPath, title: t(title) })
             }

--- a/src/components/ui/BreadcrumbList.tsx
+++ b/src/components/ui/BreadcrumbList.tsx
@@ -37,7 +37,7 @@ export const BreadcrumbList = (): JSX.Element => {
         }, [])
 
     return (
-        <Breadcrumbs aria-label="breadcrumb">
+        <Breadcrumbs>
             {breadcrumbTitles.map(({ path, title }) => (
                 <Link
                     key={path}

--- a/src/components/ui/BreadcrumbList.tsx
+++ b/src/components/ui/BreadcrumbList.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Link as RouterLink, useLocation } from 'react-router-dom'
+import { Breadcrumbs, Link } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+interface BreadcrumbItem {
+    path: string
+    title: string
+}
+
+const pathTitles: Record<string, string> = {
+    '/settings': 'settings.title',
+    '/settings/general': 'settings.general.title',
+    '/settings/profile': 'settings.profile.title',
+    '/settings/identity': 'settings.identity.title',
+    '/settings/theme': 'settings.theme.title',
+    '/settings/sound': 'settings.sound.title',
+    '/settings/emoji': 'settings.emoji.title',
+    '/settings/media': 'settings.media.title',
+    '/settings/activitypub': 'settings.ap.title',
+    '/settings/loginqr': 'settings.qr.title'
+}
+
+export const BreadcrumbList = (): JSX.Element => {
+    const { t } = useTranslation()
+    const currentPath = useLocation()
+
+    const breadcrumbTitles: BreadcrumbItem[] = currentPath.pathname
+        .split('/')
+        .reduce<BreadcrumbItem[]>((acc, path, index, paths) => {
+            const currentPath = `/${paths.slice(1, index + 1).join('/')}`
+            const title = pathTitles[currentPath]
+            if (title) {
+                acc.push({ path: currentPath, title: t(title) })
+            }
+            return acc
+        }, [])
+
+    return (
+        <Breadcrumbs aria-label="breadcrumb">
+            {breadcrumbTitles.map(({ path, title }) => (
+                <Link
+                    key={path}
+                    component={RouterLink}
+                    to={path}
+                    variant="h2"
+                    underline="hover"
+                    color="inherit"
+                    sx={{
+                        textTransform: 'capitalize',
+                        color: 'text.primary'
+                    }}
+                >
+                    {title}
+                </Link>
+            ))}
+        </Breadcrumbs>
+    )
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -12,6 +12,19 @@ import { APSettings } from '../components/Settings/APSettings'
 import { IdentitySettings } from '../components/Settings/Identity'
 import { BreadcrumbList } from '../components/ui/BreadcrumbList'
 
+const pathTitles: Record<string, string> = {
+    '/settings': 'settings.title',
+    '/settings/general': 'settings.general.title',
+    '/settings/profile': 'settings.profile.title',
+    '/settings/identity': 'settings.identity.title',
+    '/settings/theme': 'settings.theme.title',
+    '/settings/sound': 'settings.sound.title',
+    '/settings/emoji': 'settings.emoji.title',
+    '/settings/media': 'settings.media.title',
+    '/settings/activitypub': 'settings.ap.title',
+    '/settings/loginqr': 'settings.qr.title'
+}
+
 export function Settings(): JSX.Element {
     return (
         <Box
@@ -25,7 +38,7 @@ export function Settings(): JSX.Element {
                 overflowY: 'scroll'
             }}
         >
-            <BreadcrumbList />
+            <BreadcrumbList pathTitles={pathTitles} />
             <Divider />
             <Routes>
                 <Route path="/" element={<SettingsIndex />} />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
-import { Divider, Box, Breadcrumbs, Link } from '@mui/material'
-import { Route, Routes, useLocation, Link as RouterLink } from 'react-router-dom'
+import { Divider, Box } from '@mui/material'
+import { Route, Routes } from 'react-router-dom'
 import { SettingsIndex } from '../components/Settings/Index'
 import { GeneralSettings } from '../components/Settings/General'
 import { ProfileSettings } from '../components/Settings/Profile'
@@ -9,14 +9,10 @@ import { EmojiSettings } from '../components/Settings/Emoji'
 import { MediaSettings } from '../components/Settings/Media'
 import { LoginQR } from '../components/Settings/LoginQR'
 import { APSettings } from '../components/Settings/APSettings'
-import { useTranslation } from 'react-i18next'
 import { IdentitySettings } from '../components/Settings/Identity'
+import { BreadcrumbList } from '../components/ui/BreadcrumbList'
 
 export function Settings(): JSX.Element {
-    const path = useLocation()
-
-    const { t } = useTranslation('', { keyPrefix: 'pages.settings' })
-
     return (
         <Box
             sx={{
@@ -29,26 +25,7 @@ export function Settings(): JSX.Element {
                 overflowY: 'scroll'
             }}
         >
-            <Breadcrumbs>
-                <Link variant="h2" component={RouterLink} underline="hover" color="text.primary" to="/settings">
-                    {t('title')}
-                </Link>
-                {path.pathname !== '/settings' && (
-                    <Link
-                        variant="h2"
-                        underline="hover"
-                        color="inherit"
-                        to={path.pathname}
-                        component={RouterLink}
-                        sx={{
-                            textTransform: 'capitalize',
-                            color: 'text.primary'
-                        }}
-                    >
-                        {path.pathname.split('/')[2]}
-                    </Link>
-                )}
-            </Breadcrumbs>
+            <BreadcrumbList />
             <Divider />
             <Routes>
                 <Route path="/" element={<SettingsIndex />} />


### PR DESCRIPTION
#515 

## やったこと

- uiディレクトリ下にパンくずリストのコンポーネントを作成
- コンポーネントを呼ぶだけでカレントパスから多言語対応済のパンくずリストを表示できるようにした

## 問題点？

- 対応したいページが増えた場合にはBreacrumbList.tsx > pathTitlesのメンテが必要