### PR TITLE
add horizontal padding to emoji reaction

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/src/components/Message/MessageReactions.tsx
+++ b/src/components/Message/MessageReactions.tsx
@@ -108,7 +108,8 @@ export const MessageReactions = (props: MessageReactionsProps): JSX.Element => {
                 >
                     <Button
                         sx={{
-                            p: 0,
+                            py: 0,
+                            px: 1,
                             gap: 1,
                             display: 'flex',
                             backgroundColor: ownReactions[imageUrl]


### PR DESCRIPTION
長い絵文字リアクション用のpaddingを追加

Before:
![image](https://github.com/totegamma/concurrent-world/assets/5954030/15ced102-9ce5-4987-8279-e7a41b573e94)

After:
![image](https://github.com/totegamma/concurrent-world/assets/5954030/bc293d91-e205-4b1c-9d43-7ba58f5c8e09)
