### PR TITLE
Tweak/fix initial language blank

### DIFF
--- a/src/components/Settings/General.tsx
+++ b/src/components/Settings/General.tsx
@@ -36,7 +36,7 @@ export const GeneralSettings = (): JSX.Element => {
     const { t, i18n } = useTranslation('', { keyPrefix: 'settings.general' })
 
     useEffect(() => {
-        setCurrentLanguage(i18n.language)
+        setCurrentLanguage(i18n.resolvedLanguage || '')
     }, [])
 
     return (

--- a/src/components/Settings/General.tsx
+++ b/src/components/Settings/General.tsx
@@ -36,7 +36,7 @@ export const GeneralSettings = (): JSX.Element => {
     const { t, i18n } = useTranslation('', { keyPrefix: 'settings.general' })
 
     useEffect(() => {
-        setCurrentLanguage(i18n.resolvedLanguage || '')
+        setCurrentLanguage(i18n.resolvedLanguage || 'en')
     }, [])
 
     return (


### PR DESCRIPTION
ログインしたばかりの状態だと、言語選択メニューで言語が空になる
![image](https://github.com/totegamma/concurrent-world/assets/5954030/157841c1-4fd0-48b0-bf59-a82ea319b469)

対策としてi18nextの`i18n.language`の代わりに`i18n.resolvedLanguage`にする(そうすると正しいキーにしてくれる。例えば`en-US`のresolvedLanguageは`en`など)
参考：https://www.i18next.com/overview/api#resolvedlanguage
![image](https://github.com/totegamma/concurrent-world/assets/5954030/ea6db9cb-9629-41d6-976e-a1ef7f1b03c0)
