### PR TITLE
Issue #530

### DIFF
--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -194,7 +194,7 @@ export function ListPage(): JSX.Element {
                                 alignItems: 'center'
                             }}
                         >
-                            <Button component={RouterLink} to="/explorer">
+                            <Button component={RouterLink} to="/explorer/streams">
                                 <Typography variant="h1" sx={{ fontWeight: 600, mx: 1 }}>
                                     Go Explore
                                 </Typography>


### PR DESCRIPTION
〇 新しくリストを作成した際に表示される"GO EXPLORE"のリンクの向き先が新しいものに変更されていなかったため修正
   (/explorer/streams に変更)