### PR TITLE
Remove type from video tag

### DIFF
--- a/src/components/Draft.tsx
+++ b/src/components/Draft.tsx
@@ -183,7 +183,7 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
         } else {
             setDraft(draft.replace(uploadingText, ''))
             if (imageFile.type.startsWith('video')) {
-                setDraft(draft + `<video controls><source src="${result}" type="${imageFile.type}"></video>`)
+                setDraft(draft + `<video controls><source src="${result}"></video>`)
             } else {
                 setDraft(draft + `![image](${result})`)
             }

--- a/src/components/MobileDraft.tsx
+++ b/src/components/MobileDraft.tsx
@@ -145,7 +145,7 @@ export const MobileDraft = memo<MobileDraftProps>((props: MobileDraftProps): JSX
         } else {
             setDraft(draft.replace(uploadingText, ''))
             if (imageFile.type.startsWith('video')) {
-                setDraft(draft + `<video controls><source src="${result}" type="${imageFile.type}"></video>`)
+                setDraft(draft + `<video controls><source src="${result}"></video>`)
             } else {
                 setDraft(draft + `![image](${result})`)
             }


### PR DESCRIPTION
# PR内容
Videoタグで`type`が`video/quicktime`だとChromeで再生されないのでどうにかするやつ
#603 

Issueのコメントでそもそも`type`いらないかも？ってなったので、`type`を削除しました。

# 動作確認

- Windows版Chrome
OK
- Android版Chrome
OK
- iOS版Safari
OK