### PR TITLE
Fixed display of video thumbnails in Safari

### DIFF
--- a/src/components/Draft.tsx
+++ b/src/components/Draft.tsx
@@ -183,7 +183,7 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
         } else {
             setDraft(draft.replace(uploadingText, ''))
             if (imageFile.type.startsWith('video')) {
-                setDraft(draft + `<video controls><source src="${result}"></video>`)
+                setDraft(draft + `<video controls><source src="${result}#t=0.1"></video>`)
             } else {
                 setDraft(draft + `![image](${result})`)
             }

--- a/src/components/MobileDraft.tsx
+++ b/src/components/MobileDraft.tsx
@@ -145,7 +145,7 @@ export const MobileDraft = memo<MobileDraftProps>((props: MobileDraftProps): JSX
         } else {
             setDraft(draft.replace(uploadingText, ''))
             if (imageFile.type.startsWith('video')) {
-                setDraft(draft + `<video controls><source src="${result}"></video>`)
+                setDraft(draft + `<video controls><source src="${result}#t=0.1"></video>`)
             } else {
                 setDraft(draft + `![image](${result})`)
             }


### PR DESCRIPTION
# PR内容
iOSのSafariで動画のサムネイルが表示されないので表示させるやつ
#604 

動画URLに`#t=0.1`をつけると表示されるので、追加するように変更しました。

# 動作確認

- Windows版Chrome
OK
- Android版Chrome
OK
- iOS版Safari
OK