### PR TITLE
画像を開いた時に右クリックに画像保存が出てこなかった問題を修正

### DIFF
--- a/src/context/MediaViewer.tsx
+++ b/src/context/MediaViewer.tsx
@@ -155,7 +155,7 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
                                 setContainer(el)
                             }}
                             onClick={(e) => {
-                                if (e.target !== imageRef.current?.parentElement) {
+                                if (e.target !== imageRef.current) {
                                     close()
                                 }
                             }}
@@ -180,6 +180,9 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
                                     >
                                         <img
                                             src={getImageURL(previewImage)}
+                                            style={{
+                                                pointerEvents: 'auto'
+                                            }}
                                             alt="preview"
                                             ref={(el: HTMLImageElement | null) => {
                                                 imageRef.current = el


### PR DESCRIPTION
Ref.
- https://github.com/BetterTyped/react-zoom-pan-pinch/issues/135#issuecomment-683463453
- https://github.com/BetterTyped/react-zoom-pan-pinch/issues/249

クリックすると閉じてしまうようになったので `onClick` も修正しました

![image](https://github.com/user-attachments/assets/b1b02ca6-a5d3-42c6-815f-5828fd9b706b)