### PR TITLE
ThinMenuへのConcord追加、メニューアイコンのサイズを視覚的に違和感が無いよう整えた

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -231,7 +231,12 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                             variant="dot"
                                             invisible={progress !== 0 || !isMasterSession}
                                         >
-                                            <MenuBookIcon sx={{ color: 'background.contrastText' }} />
+                                            <MenuBookIcon
+                                                sx={{
+                                                    color: 'background.contrastText',
+                                                    fontSize: '1.57rem'
+                                                }}
+                                            />
                                         </Badge>
                                     </Box>
                                     <ListItemText primary={t('tutorial.title')} />

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -110,11 +110,16 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                     if (res) event.preventDefault()
                                 }}
                             >
-                                <HomeIcon
+                                <Box
                                     sx={{
-                                        color: 'background.contrastText'
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        width: '1.75rem',
+                                        justifyContent: 'center'
                                     }}
-                                />
+                                >
+                                    <HomeIcon sx={{ color: 'background.contrastText' }} />
+                                </Box>
                                 <ListItemText primary={t('home.title')} />
                             </ListItemButton>
                         </ListItem>
@@ -125,23 +130,36 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                 to="/notifications"
                                 onClick={props.onClick}
                             >
-                                <NotificationsIcon
+                                <Box
                                     sx={{
-                                        color: 'background.contrastText'
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        width: '1.75rem',
+                                        justifyContent: 'center'
                                     }}
-                                />
-
+                                >
+                                    <NotificationsIcon sx={{ color: 'background.contrastText' }} />
+                                </Box>
                                 <ListItemText primary={t('notifications.title')} />
                             </ListItemButton>
                         </ListItem>
                         <ListItem disablePadding>
                             <ListItemButton sx={{ gap: 1 }} component={NavLink} to="/contacts" onClick={props.onClick}>
-                                <ContactsIcon
+                                <Box
                                     sx={{
-                                        color: 'background.contrastText'
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        width: '1.75rem',
+                                        justifyContent: 'center'
                                     }}
-                                />
-
+                                >
+                                    <ContactsIcon
+                                        sx={{
+                                            color: 'background.contrastText',
+                                            fontSize: '1.5rem'
+                                        }}
+                                    />
+                                </Box>
                                 <ListItemText primary={t('contacts.title')} />
                             </ListItemButton>
                         </ListItem>
@@ -152,12 +170,21 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                 to="/explorer/timelines"
                                 onClick={props.onClick}
                             >
-                                <ExploreIcon
+                                <Box
                                     sx={{
-                                        color: 'background.contrastText'
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        width: '1.75rem',
+                                        justifyContent: 'center'
                                     }}
-                                />
-
+                                >
+                                    <ExploreIcon
+                                        sx={{
+                                            color: 'background.contrastText',
+                                            fontSize: '1.65rem'
+                                        }}
+                                    />
+                                </Box>
                                 <ListItemText primary={t('explore.title')} />
                             </ListItemButton>
                         </ListItem>
@@ -169,12 +196,16 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                     to="/concord/assets"
                                     onClick={props.onClick}
                                 >
-                                    <CellTowerIcon
+                                    <Box
                                         sx={{
-                                            color: 'background.contrastText'
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            width: '1.75rem',
+                                            justifyContent: 'center'
                                         }}
-                                    />
-
+                                    >
+                                        <CellTowerIcon sx={{ color: 'background.contrastText' }} />
+                                    </Box>
                                     <ListItemText primary={'Concord'} />
                                 </ListItemButton>
                             </ListItem>
@@ -187,18 +218,22 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                     to="/tutorial"
                                     onClick={props.onClick}
                                 >
-                                    <Badge
-                                        color="secondary"
-                                        variant="dot"
-                                        invisible={progress !== 0 || !isMasterSession}
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            width: '1.75rem',
+                                            justifyContent: 'center'
+                                        }}
                                     >
-                                        <MenuBookIcon
-                                            sx={{
-                                                color: 'background.contrastText'
-                                            }}
-                                        />
-                                    </Badge>
-
+                                        <Badge
+                                            color="secondary"
+                                            variant="dot"
+                                            invisible={progress !== 0 || !isMasterSession}
+                                        >
+                                            <MenuBookIcon sx={{ color: 'background.contrastText' }} />
+                                        </Badge>
+                                    </Box>
                                     <ListItemText primary={t('tutorial.title')} />
                                 </ListItemButton>
                             </ListItem>
@@ -211,23 +246,32 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                                     to="/devtool"
                                     onClick={props.onClick}
                                 >
-                                    <TerminalIcon
+                                    <Box
                                         sx={{
-                                            color: 'background.contrastText'
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            width: '1.75rem',
+                                            justifyContent: 'center'
                                         }}
-                                    />
-
+                                    >
+                                        <TerminalIcon sx={{ color: 'background.contrastText' }} />
+                                    </Box>
                                     <ListItemText primary={t('devtool.title')} />
                                 </ListItemButton>
                             </ListItem>
                         )}
                         <ListItem disablePadding>
                             <ListItemButton sx={{ gap: 1 }} component={NavLink} to="/settings" onClick={props.onClick}>
-                                <SettingsIcon
+                                <Box
                                     sx={{
-                                        color: 'background.contrastText'
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        width: '1.75rem',
+                                        justifyContent: 'center'
                                     }}
-                                />
+                                >
+                                    <SettingsIcon sx={{ color: 'background.contrastText' }} />
+                                </Box>
                                 <ListItemText primary={t('settings.title')} />
                             </ListItemButton>
                         </ListItem>

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -113,12 +113,7 @@ export const MobileMenu = (): JSX.Element => {
                     to="/tutorial"
                 >
                     <Badge color="secondary" variant="dot" invisible={progress !== 0 || !isMasterSession}>
-                        <MenuBookIcon
-                            sx={{
-                                color: 'background.contrastText',
-                                fontSize: '1.6rem'
-                            }}
-                        />
+                        <MenuBookIcon />
                     </Badge>
                 </Button>
             )}

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -94,7 +94,12 @@ export const MobileMenu = (): JSX.Element => {
                 component={NavLink}
                 to="/contacts"
             >
-                <ContactsIcon />
+                <ContactsIcon
+                    sx={{
+                        color: 'background.contrastText',
+                        fontSize: '1.5rem'
+                    }}
+                />
             </Button>
             {!tutorialCompleted && (
                 <Button
@@ -110,7 +115,8 @@ export const MobileMenu = (): JSX.Element => {
                     <Badge color="secondary" variant="dot" invisible={progress !== 0 || !isMasterSession}>
                         <MenuBookIcon
                             sx={{
-                                color: 'background.contrastText'
+                                color: 'background.contrastText',
+                                fontSize: '1.6rem'
                             }}
                         />
                     </Badge>


### PR DESCRIPTION
## What
ThinMenuへのConcord追加
メニューアイコンのサイズを調整し外観をすっきりさせました

調整前
![CleanShot 2025-01-24 at 01 43 13@2x](https://github.com/user-attachments/assets/0efaed24-2fd2-40bd-8c31-0c2855a77128)

調整後
![CleanShot 2025-01-24 at 01 43 21@2x](https://github.com/user-attachments/assets/e3476aff-7cf3-452e-bb40-000cdb94168d)


## Why
ThinMenuにConcordが表示されていない #805
連絡先アイコンとチュートリアルアイコンが特に大きく見え散らかって見えていました

## 懸念事項 / Concerns
なし

## 動作確認 / Checks (if needed)
macOS SafariとChrome、iPhone Safariで外観の確認、メニューの動作チェック。

