### PR TITLE
アバター位置やメッセージアクションボタンの位置の微調整

### DIFF
--- a/src/components/ContentWithCCAvatar.tsx
+++ b/src/components/ContentWithCCAvatar.tsx
@@ -57,7 +57,7 @@ export const ContentWithCCAvatar = (props: ContentWithCCAvatarProps): JSX.Elemen
                         wordBreak: 'break-word',
                         alignItems: 'flex-start',
                         flex: 1,
-                        gap: 1
+                        gap: { xs: 0.5, sm: 1 }
                     }}
                     disablePadding
                 >

--- a/src/components/Message/DummyMessageView.tsx
+++ b/src/components/Message/DummyMessageView.tsx
@@ -31,7 +31,7 @@ export const DummyMessageView = (props: DummyMessageViewProps): JSX.Element => {
                 wordBreak: 'break-word',
                 alignItems: 'flex-start',
                 flex: 1,
-                gap: 1,
+                gap: { xs: 0.5, sm: 1 },
                 ...props.sx
             }}
             disablePadding
@@ -118,15 +118,21 @@ export const DummyMessageView = (props: DummyMessageViewProps): JSX.Element => {
                         <Box
                             sx={{
                                 display: props.hideActions ? 'none' : 'flex',
-                                justifyContent: 'space-between',
                                 height: '1.5rem',
+                                alignItems: 'center',
                                 overflow: 'hidden'
                             }}
                         >
                             <Box
                                 sx={{
                                     display: 'flex',
-                                    gap: { xs: 1, sm: 4 }
+                                    flexDirection: 'row',
+                                    alignItems: 'center',
+                                    justifyContent: 'space-between',
+                                    width: { xs: '60vw', sm: '50vw', md: '40vw' },
+                                    minWidth: `200px`,
+                                    maxWidth: '600px',
+                                    flexShrink: 0
                                 }}
                             >
                                 {/* left */}

--- a/src/components/Message/MessageActions.tsx
+++ b/src/components/Message/MessageActions.tsx
@@ -82,7 +82,6 @@ export const MessageActions = (props: MessageActionsProps): JSX.Element => {
                     alignItems: 'center',
                     justifyContent: 'space-between',
                     width: { xs: '60vw', sm: '50vw', md: '40vw' },
-                    minWidth: `180px`,
                     maxWidth: '600px',
                     flexShrink: 0
                 }}

--- a/src/components/Message/MessageActions.tsx
+++ b/src/components/Message/MessageActions.tsx
@@ -82,6 +82,8 @@ export const MessageActions = (props: MessageActionsProps): JSX.Element => {
                     alignItems: 'center',
                     justifyContent: 'space-between',
                     width: { xs: '60vw', sm: '50vw', md: '40vw' },
+                    minWidth: `180px`,
+                    maxWidth: '600px',
                     flexShrink: 0
                 }}
             >

--- a/src/components/ui/IconButtonWithNumber.tsx
+++ b/src/components/ui/IconButtonWithNumber.tsx
@@ -14,7 +14,6 @@ const _IconButtonWithNumber: ForwardRefRenderFunction<HTMLDivElement, IconButton
             {...props}
             sx={{
                 display: 'flex',
-                width: '3rem',
                 alignItems: 'center'
             }}
             ref={ref}
@@ -24,7 +23,7 @@ const _IconButtonWithNumber: ForwardRefRenderFunction<HTMLDivElement, IconButton
         >
             <IconButton
                 sx={{
-                    p: 0.5,
+                    p: 0,
                     color: theme.palette.text.primary,
                     fontSize: '1.5rem'
                 }}

--- a/src/components/ui/IconButtonWithNumber.tsx
+++ b/src/components/ui/IconButtonWithNumber.tsx
@@ -14,7 +14,13 @@ const _IconButtonWithNumber: ForwardRefRenderFunction<HTMLDivElement, IconButton
             {...props}
             sx={{
                 display: 'flex',
-                alignItems: 'center'
+                flesShrink: 1,
+                flexBasis: '0%',
+                alignItems: 'center',
+                flexGrow: 1,
+                '&:last-child': {
+                    flexGrow: 0 // 最後の要素は伸びない
+                }
             }}
             ref={ref}
             onClick={(e) => {

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -284,7 +284,7 @@ export function ListPage(): JSX.Element {
                                                 streamPickerInitial={postStreams}
                                                 defaultPostHome={defaultPostHome}
                                                 sx={{
-                                                    p: 1
+                                                    p: { xs: 0.5, sm: 1 }
                                                 }}
                                             />
                                             <Divider sx={{ mx: { xs: 0.5, sm: 1, md: 1 } }} />

--- a/src/pages/StreamPage.tsx
+++ b/src/pages/StreamPage.tsx
@@ -136,7 +136,7 @@ export const StreamPage = memo((): JSX.Element => {
                                                 streamPickerInitial={streams}
                                                 streamPickerOptions={[...new Set([...allKnownTimelines, ...streams])]}
                                                 sx={{
-                                                    p: 1
+                                                    p: { xs: 0.5, sm: 1 }
                                                 }}
                                             />
                                             <Divider sx={{ mx: { xs: 0.5, sm: 1, md: 1 } }} />


### PR DESCRIPTION
## What
以下の要素の位置が揃います
プレビューとタイムライン中のアバター
プレビューのメッセージアクションボタンとタイムライン中のメッセージアクションボタン

高解像度環境で最大化したときにメッセージアクションボタンが領域外にはみ出なくなります

## Why
心地良くするため

## 懸念事項 / Concerns
なし

## 動作確認 / Checks (if needed)
macOS SafariとChrome、iPhone Safariでの確認