### PR TITLE
Remove base64 encoding for S3 uploads

### DIFF
--- a/app/src/context/StorageContext.tsx
+++ b/app/src/context/StorageContext.tsx
@@ -36,15 +36,6 @@ export const StorageProvider = ({ children }: { children: JSX.Element | JSX.Elem
         async (file: File, onProgress?: (_: number) => void): Promise<string> => {
             if (storageProvider === 's3') {
                 if (!s3Client) throw new Error('S3 client is not initialized')
-                const base64Data = await fileToBase64(file)
-                if (!base64Data) throw new Error('Failed to convert file to base64')
-                const _base64Data = base64Data.split(',')[1]
-                const byteCharacters = window.atob(_base64Data)
-                const byteNumbers = new Array(byteCharacters.length)
-                for (let i = 0; i < byteCharacters.length; i++) {
-                    byteNumbers[i] = byteCharacters.charCodeAt(i)
-                }
-                const byteArray = new Uint8Array(byteNumbers)
 
                 const fileName = `${Date.now()}`
                 const url = await getSignedUrl(
@@ -61,7 +52,6 @@ export const StorageProvider = ({ children }: { children: JSX.Element | JSX.Elem
                 const xhr = new XMLHttpRequest()
                 xhr.open('PUT', url, true)
                 xhr.setRequestHeader('Content-Type', file.type)
-                xhr.setRequestHeader('Content-Encoding', 'base64')
                 xhr.setRequestHeader('Content-Disposition', 'inline')
 
                 xhr.upload.onprogress = (e) => {
@@ -70,7 +60,7 @@ export const StorageProvider = ({ children }: { children: JSX.Element | JSX.Elem
                     }
                 }
 
-                xhr.send(byteArray)
+                xhr.send(file)
 
                 return await new Promise<string>((resolve, reject) => {
                     xhr.onload = () => {


### PR DESCRIPTION
## What
S3へメディアファイルをアップロードする際に、base64へ変換していた箇所を削除しました。

## Why
https://fed.brid.gy/ 経由で作成したBlueskyアカウントにて画像が正しく表示されなかったため。
おそらく`content-encoding:base64`が原因とのことで、base64への変換はせずにアップロードするようにしました。
https://concrnt.world/tote.gammalab.net/m3yh8gvpqszmqw9c606am1a2qfg

## 懸念事項 / Concerns
なし

## 動作確認 / Checks (if needed)
MinIOとR2にて下記の動作確認を行いました。

- [x] 画像、動画、3Dファイルアップロード、及びクライアント上(concrnt.world)での各メディアの表示確認
- [x] fed.brid.gy経由で作成したBlueskyアカウントで添付した画像が正しく表示されること

## その他 / Additional info (optional)
コンカレ側は関係ないんですが、どうやら動画はfed.brid.gy側がうまく処理できてないのか表示できません。
（misskey.ioのアカウントで作成したBlueskyアカウントでも同様）