### PR TITLE
reduce index bundle size

### DIFF
--- a/app/src/components/ExifInfo.tsx
+++ b/app/src/components/ExifInfo.tsx
@@ -16,14 +16,21 @@ export default function ExifInfo(props: ExifInfoProps): JSX.Element {
         fetch(props.src)
             .then((response) => response.blob())
             .then(async (blob) => {
-                const exifData = ExifReader.load(await blob.arrayBuffer())
-                const newInfos: Record<string, string> = {}
-                for (const key of props.keys) {
-                    if (exifData[key]) {
-                        newInfos[key] = exifData[key].description
+                try {
+                    const exifData = ExifReader.load(await blob.arrayBuffer())
+                    const newInfos: Record<string, string> = {}
+                    for (const key of props.keys) {
+                        if (exifData[key]) {
+                            newInfos[key] = exifData[key].description
+                        }
                     }
+                    setInfos(newInfos)
+                } catch (error) {
+                    console.error("Error parsing EXIF data:", error)
                 }
-                setInfos(newInfos)
+            })
+            .catch((error) => {
+                console.error("Error fetching image:", error)
             })
     }, [props.src, props.keys])
 

--- a/app/src/components/ExifInfo.tsx
+++ b/app/src/components/ExifInfo.tsx
@@ -1,0 +1,53 @@
+import { Box } from '@mui/material'
+import ExifReader from 'exifreader'
+import { Fragment, useEffect, useState } from 'react'
+
+interface ExifInfoProps {
+    src: string
+    keys: string[]
+}
+
+export default function ExifInfo(props: ExifInfoProps): JSX.Element {
+    const [infos, setInfos] = useState<Record<string, string>>({})
+
+    useEffect(() => {
+        setInfos({})
+
+        fetch(props.src)
+            .then((response) => response.blob())
+            .then(async (blob) => {
+                const exifData = ExifReader.load(await blob.arrayBuffer())
+                const newInfos: Record<string, string> = {}
+                for (const key of props.keys) {
+                    if (exifData[key]) {
+                        newInfos[key] = exifData[key].description
+                    }
+                }
+                setInfos(newInfos)
+            })
+    }, [props.src, props.keys])
+
+    if (Object.keys(infos).length === 0) return <></>
+
+    return (
+        <Box
+            sx={{
+                backgroundColor: 'black',
+                color: 'white',
+                fontSize: '0.5rem',
+                display: 'grid',
+                gridTemplateColumns: 'auto auto',
+                padding: 0.5
+            }}
+        >
+            {Object.keys(infos).map((key) => {
+                return (
+                    <Fragment key={key}>
+                        <Box>{key}: </Box>
+                        <Box>{infos[key]}</Box>
+                    </Fragment>
+                )
+            })}
+        </Box>
+    )
+}

--- a/app/src/components/ModelViewer.tsx
+++ b/app/src/components/ModelViewer.tsx
@@ -1,0 +1,38 @@
+import { CSSProperties, useEffect, useState } from 'react'
+
+interface ModelViewerProps {
+    src: string
+    style: CSSProperties
+}
+
+export const ModelViewer = (props: ModelViewerProps): JSX.Element => {
+    const [loaded, setLoaded] = useState(false)
+
+    useEffect(() => {
+        import('@google/model-viewer').then((_module) => {
+            setLoaded(true)
+        })
+    }, [])
+
+    if (loaded) {
+        return <model-viewer src={props.src} autoplay camera-controls style={props.style} />
+    } else {
+        return <div style={{ ...props.style }}>Loading...</div>
+    }
+}
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace JSX {
+        interface IntrinsicElements {
+            'model-viewer': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+                src: string
+                alt?: string
+                'camera-controls'?: boolean
+                'auto-rotate'?: boolean
+                ar?: boolean
+                autoplay?: boolean
+            }
+        }
+    }
+}

--- a/app/src/components/NotificationTimeline.tsx
+++ b/app/src/components/NotificationTimeline.tsx
@@ -149,30 +149,36 @@ const timeline = forwardRef((props: TimelineProps, ref: ForwardedRef<VListHandle
     useEffect(() => {
         let isCancelled = false
         setTimelineLoading(true)
-        client.newTimelineQuery().then((t) => {
-            if (isCancelled) return
-            timeline.current = t
-            t.onUpdate = () => {
-                summariseNotifications().then((n) => {
-                    if (isCancelled) return
-                    setNotifications((prev) => [...prev, ...n])
-                })
-            }
-            setNotifications([])
-            iter.current = 0
-            timeline.current
-                .init(props.timeline, props.query, props.batchSize ?? 16)
-                .then((hasMore) => {
-                    if (isCancelled) return
-                    setHasMoreData(hasMore)
-                })
-                .finally(() => {
-                    setTimelineLoading(false)
-                })
-            return t
-        })
+        const request = async () => {
+            return client.newTimelineQuery().then((t) => {
+                if (isCancelled) return
+                timeline.current = t
+                t.onUpdate = () => {
+                    summariseNotifications().then((n) => {
+                        if (isCancelled) return
+                        setNotifications((prev) => [...prev, ...n])
+                    })
+                }
+                setNotifications([])
+                iter.current = 0
+                timeline.current
+                    .init(props.timeline, props.query, props.batchSize ?? 16)
+                    .then((hasMore) => {
+                        if (isCancelled) return
+                        setHasMoreData(hasMore)
+                    })
+                    .finally(() => {
+                        setTimelineLoading(false)
+                    })
+                return t
+            })
+        }
+        const mt = request()
         return () => {
             isCancelled = true
+            mt.then((t) => {
+                if (t) t.onUpdate = () => {}
+            })
         }
     }, [props.timeline, props.query, client])
 

--- a/app/src/components/ui/EmbeddedGallery.tsx
+++ b/app/src/components/ui/EmbeddedGallery.tsx
@@ -13,9 +13,9 @@ import FullscreenIcon from '@mui/icons-material/Fullscreen'
 
 import poster from '../../resources/view-3dmodel.png'
 
-import '@google/model-viewer'
 import { CCIconButton } from './CCIconButton'
 import { useTranslation } from 'react-i18next'
+import { ModelViewer } from '../ModelViewer'
 
 export interface EmbeddedGalleryProps {
     medias: WorldMedia[]
@@ -148,10 +148,8 @@ export const MediaCard = ({ media, onExpand }: { media: WorldMedia; onExpand?: (
                             }}
                         >
                             {showModel ? (
-                                <model-viewer
+                                <ModelViewer
                                     src={media.mediaURL}
-                                    autoplay
-                                    camera-controls
                                     style={{
                                         backgroundColor: '#3f3f3f',
                                         width: '100%',
@@ -355,20 +353,4 @@ export const EmbeddedGallery = (props: EmbeddedGalleryProps): JSX.Element => {
             )}
         </Box>
     )
-}
-
-declare global {
-    // eslint-disable-next-line @typescript-eslint/no-namespace
-    namespace JSX {
-        interface IntrinsicElements {
-            'model-viewer': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
-                src: string
-                alt?: string
-                'camera-controls'?: boolean
-                'auto-rotate'?: boolean
-                ar?: boolean
-                autoplay?: boolean
-            }
-        }
-    }
 }

--- a/app/src/context/MediaViewer.tsx
+++ b/app/src/context/MediaViewer.tsx
@@ -8,9 +8,7 @@ import AppsIcon from '@mui/icons-material/Apps'
 import { type WorldMedia } from '../model'
 import { useGlobalState } from './GlobalState'
 import ExifReader from 'exifreader'
-
-import '@google/model-viewer'
-
+import { ModelViewer } from '../components/ModelViewer'
 const zoomFactor = 8
 
 export interface MediaViewerState {
@@ -276,18 +274,14 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
                         )}
 
                         {previewModel && (
-                            <>
-                                <model-viewer
-                                    src={previewModel}
-                                    autoplay
-                                    camera-controls
-                                    style={{
-                                        backgroundColor: '#3f3f3f',
-                                        width: '90vw',
-                                        height: '90vh'
-                                    }}
-                                />
-                            </>
+                            <ModelViewer
+                                src={previewModel}
+                                style={{
+                                    backgroundColor: '#3f3f3f',
+                                    width: '90vw',
+                                    height: '90vh'
+                                }}
+                            />
                         )}
 
                         <Box

--- a/app/src/context/MediaViewer.tsx
+++ b/app/src/context/MediaViewer.tsx
@@ -284,7 +284,7 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
                             gap={1}
                         >
                             <Box display="flex" justifyContent="right" alignItems="center">
-                                <Suspense>
+                                <Suspense fallback={<CircularProgress />}>
                                     <ExifInfo
                                         src={getImageURL(previewImage)}
                                         keys={[

--- a/app/src/context/MediaViewer.tsx
+++ b/app/src/context/MediaViewer.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, CircularProgress, IconButton, ImageList, ImageListItem, Modal } from '@mui/material'
-import { createContext, Fragment, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { type ReactZoomPanPinchRef, TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch'
 
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft'
@@ -7,17 +7,16 @@ import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight'
 import AppsIcon from '@mui/icons-material/Apps'
 import { type WorldMedia } from '../model'
 import { useGlobalState } from './GlobalState'
-import ExifReader from 'exifreader'
 import { ModelViewer } from '../components/ModelViewer'
 const zoomFactor = 8
+
+const ExifInfo = lazy(() => import('../components/ExifInfo'))
 
 export interface MediaViewerState {
     openSingle: (src?: string) => void
     openMedias: (medias: WorldMedia[], startIndex?: number) => void
     openModel: (src?: string) => void
 }
-
-const exifKeys = ['Model', 'Lens', 'FocalLength', 'ExposureTime', 'FNumber', 'ISOSpeedRatings']
 
 const MediaViewerContext = createContext<MediaViewerState>({
     openSingle: () => {},
@@ -36,7 +35,6 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
     const [previewModel, setPreviewModel] = useState<string | undefined>()
 
     const [mode, setMode] = useState<'single' | 'gallery'>('single')
-    const [exif, setExif] = useState<ExifReader.Tags | undefined>()
 
     const { isMobileSize, getImageURL } = useGlobalState()
 
@@ -109,16 +107,8 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
         if (previewImage === undefined) {
             setImageNaturalWidth(0)
             setImageNaturalHeight(0)
-            setExif(undefined)
             return
         }
-
-        fetch(getImageURL(previewImage))
-            .then((response) => response.blob())
-            .then(async (blob) => {
-                const exifData = ExifReader.load(await blob.arrayBuffer())
-                setExif(exifData)
-            })
 
         const image = new Image()
         image.src = getImageURL(previewImage)
@@ -294,28 +284,19 @@ export const MediaViewerProvider = (props: MediaViewerProviderProps): JSX.Elemen
                             gap={1}
                         >
                             <Box display="flex" justifyContent="right" alignItems="center">
-                                {exif && (
-                                    <Box
-                                        sx={{
-                                            backgroundColor: 'black',
-                                            color: 'white',
-                                            fontSize: '0.5rem',
-                                            display: 'grid',
-                                            gridTemplateColumns: 'auto auto',
-                                            padding: 0.5
-                                        }}
-                                    >
-                                        {exifKeys.map((key) => {
-                                            if (!exif[key]) return null
-                                            return (
-                                                <Fragment key={key}>
-                                                    <Box>{key}: </Box>
-                                                    <Box>{exif[key].description}</Box>
-                                                </Fragment>
-                                            )
-                                        })}
-                                    </Box>
-                                )}
+                                <Suspense>
+                                    <ExifInfo
+                                        src={getImageURL(previewImage)}
+                                        keys={[
+                                            'Model',
+                                            'Lens',
+                                            'FocalLength',
+                                            'ExposureTime',
+                                            'FNumber',
+                                            'ISOSpeedRatings'
+                                        ]}
+                                    />
+                                </Suspense>
                             </Box>
 
                             <Box display="flex" justifyContent="center" alignItems="center" flexDirection="row">


### PR DESCRIPTION
```
dist/registerSW.js                                         0.13 kB
dist/manifest.webmanifest                                  0.86 kB
dist/index.html                                            2.03 kB │ gzip:   0.96 kB
dist/assets/tutorial-post-to-communities-Dpw5W53B.png     14.09 kB
dist/assets/view-3dmodel-Bo4_-Xto.png                     16.87 kB
dist/assets/tutorial-list-settings-CgBIFPPV.png           42.04 kB
dist/assets/cc-wallpaper-base-eHSpAHwW.png                70.11 kB
dist/assets/Bright_Post-CEQ1Lnwe.wav                     117.18 kB
dist/assets/Bright_Notification-DB4kV80i.wav             117.18 kB
dist/assets/Bubble-CnINWpi6.wav                          155.40 kB
dist/assets/Notification-Cal8-Um0.wav                    318.25 kB
dist/assets/IconButtonWithLabel-BvrZhnqd.js                0.79 kB │ gzip:   0.46 kB │ map:     3.07 kB
dist/assets/GuestTimeline-DefXRV7U.js                      2.16 kB │ gzip:   1.23 kB │ map:     9.22 kB
dist/assets/Visibility-CNGvn0XD.js                         2.87 kB │ gzip:   1.51 kB │ map:    12.03 kB
dist/assets/GuestProfile-DxteLgGl.js                       3.35 kB │ gzip:   1.69 kB │ map:    13.64 kB
dist/assets/Passport-DMdNBhG6.js                           4.14 kB │ gzip:   1.68 kB │ map:    11.47 kB
dist/assets/GuestMessage-syvljfe3.js                       4.85 kB │ gzip:   1.52 kB │ map:    23.81 kB
dist/assets/AccountImport-DUBGgoWy.js                      6.34 kB │ gzip:   2.67 kB │ map:    24.41 kB
dist/assets/Registration-BihaRnWa.js                       8.90 kB │ gzip:   3.44 kB │ map:    41.41 kB
dist/assets/index.esm-Q6pGWWWx.js                         10.62 kB │ gzip:   3.18 kB │ map:    20.79 kB
dist/assets/Welcome-hJrfsDtJ.js                           10.69 kB │ gzip:   3.64 kB │ map:    36.76 kB
dist/assets/purify.es-C_uT9hQ1.js                         22.02 kB │ gzip:   8.78 kB │ map:    93.50 kB
dist/assets/mplus1p-hiragana-normal-Bxueh3ki.js           26.13 kB │ gzip:  14.67 kB │ map:    26.30 kB
dist/assets/howler-D4cA9BTH.js                            36.92 kB │ gzip:  10.16 kB │ map:   156.12 kB
dist/assets/index-tPM6zPYa.js                             42.80 kB │ gzip:   8.19 kB │ map:   118.44 kB
dist/assets/prism-light-BONpTq44.js                       48.52 kB │ gzip:  17.93 kB │ map:   200.03 kB
dist/assets/ExifInfo-Co69y2al.js                          77.87 kB │ gzip:  25.65 kB │ map:   383.86 kB
dist/assets/TextField-DdWZKO5_.js                         90.87 kB │ gzip:  28.29 kB │ map:   522.16 kB
dist/assets/index.es-C0nqHYMu.js                         158.17 kB │ gzip:  52.98 kB │ map:   643.68 kB
dist/assets/App-CESMV97A.js                              235.70 kB │ gzip:  65.92 kB │ map: 1,045.96 kB
dist/assets/GfmRenderer-Do4Iia2T.js                      339.47 kB │ gzip: 107.90 kB │ map: 1,625.54 kB
dist/assets/Profile-CWilQAou.js                          391.16 kB │ gzip: 130.57 kB │ map: 1,863.20 kB
dist/assets/QRCodeReader-CvUjfUQe.js                     411.38 kB │ gzip: 107.74 kB │ map: 2,088.36 kB
dist/assets/index-B3jnBM5D.js                            469.01 kB │ gzip: 153.11 kB │ map: 1,966.80 kB
dist/assets/html2canvas.esm-DhaxMUmu.js                  490.46 kB │ gzip: 140.69 kB │ map: 2,013.40 kB
dist/assets/model-viewer-CsQ35wK5.js                     949.36 kB │ gzip: 264.37 kB │ map: 3,545.57 kB
dist/assets/util-TCyR852l.js                           1,559.25 kB │ gzip: 505.06 kB │ map: 4,291.70 kB
dist/assets/ConcordContext-SMC4oHQv.js                 2,566.89 kB │ gzip: 561.93 kB │ map: 9,752.16 kB
```