### PR TITLE
fix notification timeline 

### DIFF
--- a/app/src/components/NotificationTimeline.tsx
+++ b/app/src/components/NotificationTimeline.tsx
@@ -153,12 +153,6 @@ const timeline = forwardRef((props: TimelineProps, ref: ForwardedRef<VListHandle
             return client.newTimelineQuery().then((t) => {
                 if (isCancelled) return
                 timeline.current = t
-                t.onUpdate = () => {
-                    summariseNotifications().then((n) => {
-                        if (isCancelled) return
-                        setNotifications((prev) => [...prev, ...n])
-                    })
-                }
                 setNotifications([])
                 iter.current = 0
                 timeline.current
@@ -166,6 +160,10 @@ const timeline = forwardRef((props: TimelineProps, ref: ForwardedRef<VListHandle
                     .then((hasMore) => {
                         if (isCancelled) return
                         setHasMoreData(hasMore)
+                        summariseNotifications().then((n) => {
+                            if (isCancelled) return
+                            setNotifications(n)
+                        })
                     })
                     .finally(() => {
                         if (isCancelled) return
@@ -196,6 +194,9 @@ const timeline = forwardRef((props: TimelineProps, ref: ForwardedRef<VListHandle
             .then((hasMore) => {
                 setHasMoreData(hasMore)
                 alreadyFetchInThisRender = false
+                summariseNotifications().then((n) => {
+                    setNotifications((prev) => [...prev, ...n])
+                })
             })
             .finally(() => {
                 setIsFetching(false)

--- a/app/src/components/NotificationTimeline.tsx
+++ b/app/src/components/NotificationTimeline.tsx
@@ -168,6 +168,7 @@ const timeline = forwardRef((props: TimelineProps, ref: ForwardedRef<VListHandle
                         setHasMoreData(hasMore)
                     })
                     .finally(() => {
+                        if (isCancelled) return
                         setTimelineLoading(false)
                     })
                 return t


### PR DESCRIPTION
This pull request refactors the notification update logic in the `NotificationTimeline` component to streamline how notifications are summarized and set. The changes focus on simplifying the flow and ensuring notifications are updated consistently after timeline initialization and data fetching.

### Refactoring notification updates:

* Removed the `onUpdate` handler from the timeline object and instead directly invoked `summariseNotifications` after the timeline initialization. This ensures notifications are set immediately after initialization without relying on an event callback. (`app/src/components/NotificationTimeline.tsx`, [app/src/components/NotificationTimeline.tsxL156-R169](diffhunk://#diff-5da6871d8cec9a6996851dcb4f6eee192321ba1e5bda870af947319b7edd07c0L156-R169))
* Added a call to `summariseNotifications` after fetching additional data to append new notifications to the existing list. This ensures that notifications are updated incrementally as more data is loaded. (`app/src/components/NotificationTimeline.tsx`, [app/src/components/NotificationTimeline.tsxR197-R199](diffhunk://#diff-5da6871d8cec9a6996851dcb4f6eee192321ba1e5bda870af947319b7edd07c0R197-R199))