### PR TITLE
add audio reader

### DIFF
--- a/app/src/components/ui/EmbeddedGallery.tsx
+++ b/app/src/components/ui/EmbeddedGallery.tsx
@@ -109,6 +109,27 @@ export const MediaCard = ({ media, onExpand }: { media: WorldMedia; onExpand?: (
                         </Box>
                     )}
 
+                    {media.mediaType.startsWith('audio') && (
+                        <Box
+                            sx={{
+                                position: 'relative',
+                                width: '100%',
+                                height: '100%',
+                                overflow: 'hidden'
+                            }}
+                        >
+                            <audio
+                                controls
+                                src={media.mediaURL}
+                                preload="metadata"
+                                style={{
+                                    width: '100%',
+                                    height: '100%'
+                                }}
+                            />
+                        </Box>
+                    )}
+
                     {media.mediaType.startsWith('video') && (
                         <Box
                             ref={videoRef}


### PR DESCRIPTION
This pull request adds support for rendering audio files in the `MediaCard` component within the `EmbeddedGallery` UI. The change ensures that audio media types are handled properly by introducing an audio player element.

### Enhancements to MediaCard component:

* [`app/src/components/ui/EmbeddedGallery.tsx`](diffhunk://#diff-4a94482337e00fe877f0797615b3dc8d8428f76be5991f6c35aaa53af475fa0dR112-R132): Added a conditional block to render an `<audio>` element for media items with a `mediaType` that starts with "audio". The audio player includes controls, uses the media's URL as the source, and is styled to fit the container dimensions.