### PR TITLE
add ap user page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -40,6 +40,7 @@ import { Schemas } from '@concrnt/worldlib'
 import type { ProfileSchema, ReplyAssociationSchema } from '@concrnt/worldlib'
 import { SearchDrawerProvider } from './context/SearchDrawer'
 import { CommandPaletteProvider } from './context/CommandPalette'
+import { ApUserPage } from './pages/ApUser'
 
 const SwitchMasterToSub = lazy(() => import('./components/SwitchMasterToSub'))
 
@@ -505,6 +506,7 @@ function App(): JSX.Element {
                                     path="/notifications"
                                     element={<Notifications latestNotification={latestNotificationDate} />}
                                 />
+                                <Route path="/ap/:id" element={<ApUserPage />} />
                                 <Route path="/devtool" element={<Devtool />} />
                                 <Route path="/subscriptions" element={<ManageSubsPage />} />
                                 <Route path="/concord/*" element={<ConcordPage />} />

--- a/app/src/components/ContentWithCCAvatar.tsx
+++ b/app/src/components/ContentWithCCAvatar.tsx
@@ -20,6 +20,7 @@ export interface ContentWithCCAvatarProps {
     avatarOverride?: string
     children?: JSX.Element | Array<JSX.Element | undefined>
     sx?: SxProps
+    apId?: string
 }
 
 export const ContentWithCCAvatar = (props: ContentWithCCAvatarProps): JSX.Element => {
@@ -27,6 +28,8 @@ export const ContentWithCCAvatar = (props: ContentWithCCAvatarProps): JSX.Elemen
     const location = useLocation()
 
     const navigateTo = props.linkTo ?? `/${props.message?.author}/${props.message?.id}`
+
+    const apLink = props.apId ? `/ap/${props.apId}` : undefined
 
     return (
         <>
@@ -100,13 +103,11 @@ export const ContentWithCCAvatar = (props: ContentWithCCAvatarProps): JSX.Elemen
                                 }}
                                 component={routerLink}
                                 to={
-                                    props.profileOverride?.link ??
+                                    apLink ??
                                     '/' +
                                         (props.author?.ccid ?? '') +
                                         (props.profileOverride?.profileID ? '#' + props.profileOverride.profileID : '')
                                 }
-                                target={props.profileOverride?.link ? '_blank' : undefined}
-                                rel={props.profileOverride?.link ? 'noopener noreferrer' : undefined}
                             >
                                 <CCAvatar
                                     avatarURL={props.author?.profile?.avatar}

--- a/app/src/components/Message/MessageViewBase.tsx
+++ b/app/src/components/Message/MessageViewBase.tsx
@@ -74,7 +74,7 @@ export const MessageViewBase = (props: MessageViewProps): JSX.Element => {
         try {
             const url = new URL(actor)
             const parts = url.pathname.split('/').filter(Boolean) // Split and remove empty segments
-            return parts.length > 1 ? parts[parts.length - 1] + '@' + url.hostname : undefined
+            return parts.length >= 1 ? parts[parts.length - 1] + '@' + url.hostname : undefined
         } catch {
             return undefined // Return undefined if the URL is invalid
         }

--- a/app/src/components/Message/MessageViewBase.tsx
+++ b/app/src/components/Message/MessageViewBase.tsx
@@ -62,6 +62,20 @@ export const MessageViewBase = (props: MessageViewProps): JSX.Element => {
         return Aids.every((v, i) => v === Bids[i])
     }, [props.rerouted, props.message])
 
+    const apId = useMemo(() => {
+        const actor = props.message.document.meta?.apActor
+        if (!actor) return undefined
+
+        if (actor.startsWith('https://bsky.brid.gy/')) {
+            const id = actor.split('/').pop()
+            return '@' + id + '@bsky.brid.gy'
+        }
+
+        const split = actor.split('/')
+
+        return split.length > 0 ? split[split.length - 1] + '@' + split[split.length - 2] : undefined
+    }, [props.message])
+
     return (
         <ContentWithCCAvatar
             message={props.message}
@@ -69,6 +83,7 @@ export const MessageViewBase = (props: MessageViewProps): JSX.Element => {
             profileOverride={props.message.document.body.profileOverride}
             avatarOverride={characterOverride?.parsedDoc.body.avatar}
             characterOverride={characterOverride?.parsedDoc.body}
+            apId={apId}
         >
             <MessageHeader
                 usernameOverride={characterOverride?.parsedDoc.body.username}

--- a/app/src/components/Message/MessageViewBase.tsx
+++ b/app/src/components/Message/MessageViewBase.tsx
@@ -71,9 +71,13 @@ export const MessageViewBase = (props: MessageViewProps): JSX.Element => {
             return '@' + id + '@bsky.brid.gy'
         }
 
-        const split = actor.split('/')
-
-        return split.length > 0 ? split[split.length - 1] + '@' + split[split.length - 2] : undefined
+        try {
+            const url = new URL(actor)
+            const parts = url.pathname.split('/').filter(Boolean) // Split and remove empty segments
+            return parts.length > 1 ? parts[parts.length - 1] + '@' + url.hostname : undefined
+        } catch {
+            return undefined // Return undefined if the URL is invalid
+        }
     }, [props.message])
 
     return (

--- a/app/src/pages/ApUser.tsx
+++ b/app/src/pages/ApUser.tsx
@@ -1,0 +1,340 @@
+import {
+    Alert,
+    alpha,
+    Box,
+    Button,
+    Collapse,
+    Divider,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Typography,
+    useTheme
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { TimelineHeader } from '../components/TimelineHeader'
+import { useClient } from '../context/ClientContext'
+import { CCWallpaper } from '../components/ui/CCWallpaper'
+import { CCIconButton } from '../components/ui/CCIconButton'
+import { CCAvatar } from '../components/ui/CCAvatar'
+import { enqueueSnackbar } from 'notistack'
+
+import AlternateEmailIcon from '@mui/icons-material/AlternateEmail'
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
+import GfmRenderer from '../components/ui/GfmRenderer'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+
+interface Stats {
+    follows: string[]
+    followers: string[]
+}
+
+export function ApUserPage(): JSX.Element {
+    const { client } = useClient()
+    const { id } = useParams()
+    const theme = useTheme()
+
+    const [person, setPerson] = useState<any>(null)
+    const [showHeader, setShowHeader] = useState(false)
+    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null)
+
+    const name = person?.name || person?.preferredUsername || id
+
+    const [stats, setStats] = useState<Stats | null>(null)
+
+    const getStats = (): void => {
+        client.api.fetchWithCredential<Stats>(client.host, `/ap/api/stats`, {}).then((data) => {
+            setStats(data.content)
+        })
+    }
+
+    useEffect(() => {
+        getStats()
+    }, [])
+
+    const follow = (target: string): void => {
+        client.api
+            .fetchWithCredential(client.host, `/ap/api/follow/${target}`, {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json'
+                }
+            })
+            .then((_data) => {
+                getStats()
+            })
+    }
+
+    const unFollow = (target: string): void => {
+        client.api
+            .fetchWithCredential(client.host, `/ap/api/follow/${target}`, {
+                method: 'DELETE',
+                headers: {
+                    'content-type': 'application/json'
+                }
+            })
+            .then((_data) => {
+                getStats()
+            })
+    }
+
+    const following = stats?.follows.includes(person?.id || '') || false
+    const followed = stats?.followers.includes(person?.id || '') || false
+
+    useEffect(() => {
+        if (!id) return
+        client.api
+            .fetchWithCredential(client.host, `/ap/api/resolve/${encodeURIComponent(id)}`, {
+                method: 'GET',
+                headers: {
+                    accept: 'application/ld+json'
+                },
+                cache: 'force-cache'
+            })
+            .then((data) => {
+                setPerson(data.content)
+            })
+    }, [id])
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                backgroundColor: 'background.paper',
+                minHeight: '100%',
+                position: 'relative',
+                overflowY: 'auto'
+            }}
+        >
+            <Box position="absolute" top="0" left="0" width="100%" zIndex="1">
+                <Collapse in={showHeader}>
+                    <TimelineHeader title={name} titleIcon={<AlternateEmailIcon />} />
+                </Collapse>
+            </Box>
+
+            <Box
+                sx={{
+                    position: 'relative'
+                }}
+            >
+                <CCWallpaper
+                    override={person?.image?.url}
+                    sx={{
+                        height: '150px'
+                    }}
+                    isLoading={!person}
+                />
+
+                <Box
+                    sx={{
+                        position: 'absolute',
+                        top: '10px',
+                        right: '10px',
+                        zIndex: 1,
+                        display: 'flex',
+                        gap: 1
+                    }}
+                >
+                    <CCIconButton
+                        sx={{
+                            backgroundColor: alpha(theme.palette.primary.main, 0.5),
+                            '&:hover': {
+                                backgroundColor: alpha(theme.palette.primary.main, 0.7)
+                            }
+                        }}
+                        onClick={(e) => {
+                            setMenuAnchor(e.currentTarget)
+                        }}
+                    >
+                        <MoreHorizIcon
+                            sx={{
+                                color: theme.palette.primary.contrastText
+                            }}
+                        />
+                    </CCIconButton>
+                </Box>
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        position: 'absolute',
+                        top: '90px',
+                        p: 1
+                    }}
+                >
+                    <CCAvatar
+                        isLoading={!person}
+                        alt={name}
+                        avatarURL={person?.icon?.url}
+                        identiconSource={id}
+                        sx={{
+                            width: '100px',
+                            height: '100px'
+                        }}
+                    />
+                </Box>
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        p: 1
+                    }}
+                >
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            gap: 1,
+                            flexWrap: 'wrap'
+                        }}
+                    >
+                        <Box
+                            sx={{
+                                width: '100px'
+                            }}
+                        />
+                        <Box
+                            sx={{
+                                flexGrow: 1
+                            }}
+                        />
+                        <Box
+                            sx={{
+                                gap: 1,
+                                flexGrow: 1,
+                                flexShrink: 0,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'flex-end',
+                                minHeight: '32.5px'
+                            }}
+                        >
+                            <Button
+                                sx={{
+                                    flexShrink: 0
+                                }}
+                                variant={following ? 'outlined' : 'contained'}
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    if (!id) return
+                                    if (following) {
+                                        unFollow(id)
+                                    } else {
+                                        follow(id)
+                                    }
+                                }}
+                            >
+                                {following ? 'フォロー中' : 'フォローする'}
+                            </Button>
+                        </Box>
+                    </Box>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'baseline',
+                            gap: 1
+                        }}
+                    >
+                        <Typography
+                            variant="h6"
+                            sx={{
+                                fontWeight: 'bold',
+                                fontSize: { xs: '1.2rem', sm: '1.5rem', md: '1.5rem' },
+                                mt: 1
+                            }}
+                        >
+                            {name}
+                        </Typography>
+                        <Typography variant="caption">{person?.preferredUsername}</Typography>
+                    </Box>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            flexWrap: 'wrap'
+                        }}
+                    >
+                        <Typography
+                            onClick={() => {
+                                if (id) {
+                                    navigator.clipboard.writeText(id)
+                                    enqueueSnackbar('IDをコピーしました', { variant: 'success' })
+                                }
+                            }}
+                            sx={{
+                                cursor: 'pointer'
+                            }}
+                            variant="caption"
+                        >
+                            {id}
+                        </Typography>
+                        {followed && <Typography variant="caption">フォローされています</Typography>}
+                    </Box>
+
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 1
+                        }}
+                    >
+                        <GfmRenderer messagebody={person?.summary || person?.description || ''} />
+                    </Box>
+                </Box>
+                <Menu
+                    anchorEl={menuAnchor}
+                    open={Boolean(menuAnchor)}
+                    onClose={() => {
+                        setMenuAnchor(null)
+                    }}
+                >
+                    <MenuItem
+                        onClick={() => {
+                            setMenuAnchor(null)
+                            if (person?.url) {
+                                window.open(person.url, '_blank', 'noopener,noreferrer')
+                            }
+                        }}
+                    >
+                        <ListItemIcon>
+                            <OpenInNewIcon
+                                sx={{
+                                    color: 'text.primary'
+                                }}
+                            />
+                        </ListItemIcon>
+                        <ListItemText>リモートで開く</ListItemText>
+                    </MenuItem>
+                </Menu>
+            </Box>
+            <Divider />
+
+            <Alert
+                sx={{
+                    margin: 2
+                }}
+                severity="info"
+                action={
+                    <Button
+                        variant="text"
+                        color="inherit"
+                        size="small"
+                        onClick={() => {
+                            if (person.url) {
+                                window.open(person.url, '_blank', 'noopener,noreferrer')
+                            }
+                        }}
+                    >
+                        リモートで開く
+                    </Button>
+                }
+            >
+                このユーザーはActivityPubのユーザーです。
+            </Alert>
+        </Box>
+    )
+}


### PR DESCRIPTION
This pull request introduces a new `ApUserPage` component to display ActivityPub user profiles, updates routing to include this page, and enhances existing components to support ActivityPub-specific functionality. Below is a summary of the most important changes:

### Addition of `ApUserPage` Component:
* Created a new `ApUserPage` component to display ActivityPub user profiles, including user details, follow/unfollow functionality, and integration with the ActivityPub API. (`app/src/pages/ApUser.tsx`)

### Routing Updates:
* Added a new route `/ap/:id` to render the `ApUserPage` for ActivityPub user profiles. (`app/src/App.tsx`)
* Imported the `ApUserPage` component into the main application file for use in routing. (`app/src/App.tsx`)

### Enhancements to `ContentWithCCAvatar` Component:
* Added a new `apId` prop to the `ContentWithCCAvatar` component to support linking to ActivityPub user profiles. (`app/src/components/ContentWithCCAvatar.tsx`)
* Updated the component logic to prioritize the `apId` prop when constructing profile links. (`app/src/components/ContentWithCCAvatar.tsx`) [[1]](diffhunk://#diff-031addadd9e7a4d3789353b9f0a58c6bc9fad5873899b395acf1dada7b369b16R32-R33) [[2]](diffhunk://#diff-031addadd9e7a4d3789353b9f0a58c6bc9fad5873899b395acf1dada7b369b16L103-L109)

### Integration with `MessageViewBase` Component:
* Added logic to derive `apId` from ActivityPub actor metadata in messages, enabling seamless linking to ActivityPub profiles. (`app/src/components/Message/MessageViewBase.tsx`)