### PR TITLE
Feat/preserve tl position

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -61,6 +61,7 @@
     "react-markdown": "^10.1.0",
     "react-parallax-tilt": "^1.7.295",
     "react-qrcode-logo": "^3.0.0",
+    "react-reverse-portal": "^2.3.0",
     "react-router-dom": "^6.11.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-zoom-pan-pinch": "^3.4.2",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -42,6 +42,7 @@ import { SearchDrawerProvider } from './context/SearchDrawer'
 import { CommandPaletteProvider } from './context/CommandPalette'
 import { ApUserPage } from './pages/ApUser'
 import { DeckPage } from './pages/Deck'
+import { TimelineProvider } from './context/TimelineProvider'
 
 const SwitchMasterToSub = lazy(() => import('./components/SwitchMasterToSub'))
 
@@ -341,9 +342,11 @@ function App(): JSX.Element {
                                             <UserDrawerProvider>
                                                 <SearchDrawerProvider>
                                                     <ConfirmProvider>
-                                                        <CommandPaletteProvider>
-                                                            <GlobalActionsProvider>{childs}</GlobalActionsProvider>
-                                                        </CommandPaletteProvider>
+                                                        <TimelineProvider>
+                                                            <CommandPaletteProvider>
+                                                                <GlobalActionsProvider>{childs}</GlobalActionsProvider>
+                                                            </CommandPaletteProvider>
+                                                        </TimelineProvider>
                                                     </ConfirmProvider>
                                                 </SearchDrawerProvider>
                                             </UserDrawerProvider>

--- a/app/src/components/RealtimeTimeline.tsx
+++ b/app/src/components/RealtimeTimeline.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, ListItem, ListItemIcon, ListItemText, type SxProps, Typography, useTheme } from '@mui/material'
-import React, { memo, useEffect, useState, useRef, forwardRef, type ForwardedRef } from 'react'
+import React, { memo, useEffect, useState, useRef, forwardRef, type ForwardedRef, useLayoutEffect } from 'react'
 import { AssociationFrame } from './Association/AssociationFrame'
 import { Loading } from './ui/Loading'
 import { MessageContainer } from './Message/MessageContainer'
@@ -15,6 +15,7 @@ import { UseSoundFormats } from '../constants'
 import { useGlobalState } from '../context/GlobalState'
 import { PullToRefresh } from './PullToRefresh'
 import { useTranslation } from 'react-i18next'
+import { useLocation } from 'react-router-dom'
 
 export interface RealtimeTimelineProps {
     timelineFQIDs: string[]
@@ -144,6 +145,15 @@ const timeline = forwardRef((props: RealtimeTimelineProps, ref: ForwardedRef<VLi
             })
     }
 
+    const location = useLocation()
+
+    // restore scroll position
+    useLayoutEffect(() => {
+        if (!ref) return
+        const handle = ref as React.RefObject<VListHandle>
+        handle.current?.scrollTo(positionRef.current)
+    }, [location.pathname])
+
     return (
         <PullToRefresh positionRef={positionRef} isFetching={isFetching} onRefresh={onRefresh}>
             <VList
@@ -161,7 +171,7 @@ const timeline = forwardRef((props: RealtimeTimelineProps, ref: ForwardedRef<VLi
                     positionRef.current = top
                     props.onScroll?.(top)
                 }}
-                onRangeChange={(_, end) => {
+                onRangeChange={(start, end) => {
                     if (end + 3 > count && hasMoreData) readMore()
                 }}
                 ref={ref}

--- a/app/src/context/TimelineProvider.tsx
+++ b/app/src/context/TimelineProvider.tsx
@@ -1,0 +1,77 @@
+import { createContext, RefObject, useCallback, useContext, useMemo, useRef, useState } from 'react'
+import { createHtmlPortalNode, HtmlPortalNode, InPortal } from 'react-reverse-portal'
+import { RealtimeTimeline } from '../components/RealtimeTimeline'
+import { VListHandle } from 'virtua'
+
+export interface TimelineContextState {
+    timelinePortal: HtmlPortalNode
+    setTimelines: (timelines: string[]) => void
+    timelineRef: RefObject<VListHandle>
+}
+
+export const TimelineContext = createContext<TimelineContextState | undefined>(undefined)
+
+export interface TimelineProviderProps {
+    children: JSX.Element
+}
+
+export const TimelineProvider = (props: TimelineProviderProps): JSX.Element => {
+    const timelinePortal = useMemo(
+        () =>
+            createHtmlPortalNode({
+                attributes: {
+                    style: 'width: 100%; height: 100%; display: flex; flex-direction: column;'
+                }
+            }),
+        []
+    )
+
+    const [timelines, setTimelines_internal] = useState<string[]>([])
+
+    const setTimelines = useCallback(
+        (newTimelines: string[]) => {
+            if (timelines.length === newTimelines.length) {
+                const A = new Set(timelines)
+                const B = new Set(newTimelines)
+                if (A.size === B.size && [...A].every((value) => B.has(value))) {
+                    return // No change in timelines
+                }
+            }
+
+            console.log('Setting new timelines:', newTimelines)
+
+            setTimelines_internal(newTimelines)
+        },
+        [timelines]
+    )
+
+    const timelineRef = useRef<VListHandle>(null)
+
+    return (
+        <>
+            <InPortal node={timelinePortal}>
+                <RealtimeTimeline timelineFQIDs={timelines} ref={timelineRef} />
+            </InPortal>
+            <TimelineContext.Provider
+                value={useMemo(() => {
+                    return {
+                        timelinePortal,
+                        setTimelines,
+                        timelineRef
+                    }
+                }, [timelinePortal, setTimelines, timelineRef])}
+            >
+                {props.children}
+            </TimelineContext.Provider>
+        </>
+    )
+}
+
+export function useTimeline(): TimelineContextState {
+    const context = useContext(TimelineContext)
+    return {
+        timelinePortal: context?.timelinePortal ?? createHtmlPortalNode(),
+        setTimelines: context?.setTimelines ?? (() => {}),
+        timelineRef: context?.timelineRef ?? useRef<VListHandle>(null)
+    }
+}

--- a/app/src/pages/ListPage.tsx
+++ b/app/src/pages/ListPage.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Divider, Menu, Tab, Tabs, Typography } from '@mui/material
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate, Link as RouterLink, useSearchParams } from 'react-router-dom'
 import { usePreference } from '../context/PreferenceContext'
-import { RealtimeTimeline } from '../components/RealtimeTimeline'
 import { useClient } from '../context/ClientContext'
 import {
     isFulfilled,
@@ -18,7 +17,6 @@ import { ListSettings } from '../components/ListSettings'
 import ListIcon from '@mui/icons-material/List'
 import { CCDrawer } from '../components/ui/CCDrawer'
 import { TimelineHeader } from '../components/TimelineHeader'
-import { type VListHandle } from 'virtua'
 import { useGlobalState } from '../context/GlobalState'
 import { ListItemTimeline } from '../components/ui/ListItemTimeline'
 import { CCPostEditor } from '../components/Editor/CCPostEditor'
@@ -27,6 +25,8 @@ import { type StreamList } from '../model'
 import { Helmet } from 'react-helmet-async'
 import { useGlobalActions } from '../context/GlobalActions'
 import { useTranslation } from 'react-i18next'
+import { useTimeline } from '../context/TimelineProvider'
+import { OutPortal } from 'react-reverse-portal'
 
 export function ListPage(): JSX.Element {
     const { client } = useClient()
@@ -39,6 +39,9 @@ export function ListPage(): JSX.Element {
     const [lists, _setLists] = usePreference('lists')
     const [showEditorOnTop] = usePreference('showEditorOnTop')
     const [showEditorOnTopMobile] = usePreference('showEditorOnTopMobile')
+
+    const { timelinePortal, setTimelines, timelineRef } = useTimeline()
+    console.log(timelineRef.current)
 
     const tab = path.hash.replace('#', '')
     const id = lists[tab] ? tab : Object.keys(lists)[0]
@@ -53,9 +56,11 @@ export function ListPage(): JSX.Element {
 
     const [listSettingsOpen, setListSettingsOpen] = useState<boolean>(false)
 
-    const timelineRef = useRef<VListHandle>(null)
-
     const timelines = useMemo(() => subscription?.items.map((e) => e.id) ?? [], [subscription])
+    useEffect(() => {
+        if (!subscription) return
+        setTimelines(subscription.items.map((e) => e.id))
+    }, [setTimelines, subscription])
 
     const [updater, setUpdater] = useState<number>(0)
 
@@ -284,35 +289,36 @@ export function ListPage(): JSX.Element {
                 {subscription ? (
                     <>
                         {timelines.length > 0 ? (
-                            <RealtimeTimeline
-                                header={
-                                    <>
-                                        <Box
-                                            sx={{
-                                                display: {
-                                                    xs: showEditorOnTopMobile ? 'block' : 'none',
-                                                    sm: showEditorOnTop ? 'block' : 'none'
-                                                }
-                                            }}
-                                        >
-                                            <CCPostEditor
-                                                minRows={3}
-                                                maxRows={7}
-                                                subprofile={list.defaultProfile}
-                                                streamPickerOptions={allKnownTimelines}
-                                                streamPickerInitial={postTimelines}
-                                                defaultPostHome={defaultPostHome}
+                            <>
+                                <OutPortal
+                                    node={timelinePortal}
+                                    header={
+                                        <>
+                                            <Box
                                                 sx={{
-                                                    p: { xs: 0.5, sm: 1 }
+                                                    display: {
+                                                        xs: showEditorOnTopMobile ? 'block' : 'none',
+                                                        sm: showEditorOnTop ? 'block' : 'none'
+                                                    }
                                                 }}
-                                            />
-                                            <Divider sx={{ mx: { xs: 0.5, sm: 1, md: 1 } }} />
-                                        </Box>
-                                    </>
-                                }
-                                timelineFQIDs={timelines}
-                                ref={timelineRef}
-                            />
+                                            >
+                                                <CCPostEditor
+                                                    minRows={3}
+                                                    maxRows={7}
+                                                    subprofile={list.defaultProfile}
+                                                    streamPickerOptions={allKnownTimelines}
+                                                    streamPickerInitial={postTimelines}
+                                                    defaultPostHome={defaultPostHome}
+                                                    sx={{
+                                                        p: { xs: 0.5, sm: 1 }
+                                                    }}
+                                                />
+                                                <Divider sx={{ mx: { xs: 0.5, sm: 1, md: 1 } }} />
+                                            </Box>
+                                        </>
+                                    }
+                                />
+                            </>
                         ) : (
                             <Box
                                 sx={{

--- a/app/src/pages/ListPage.tsx
+++ b/app/src/pages/ListPage.tsx
@@ -41,7 +41,6 @@ export function ListPage(): JSX.Element {
     const [showEditorOnTopMobile] = usePreference('showEditorOnTopMobile')
 
     const { timelinePortal, setTimelines, timelineRef } = useTimeline()
-    console.log(timelineRef.current)
 
     const tab = path.hash.replace('#', '')
     const id = lists[tab] ? tab : Object.keys(lists)[0]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       react-qrcode-logo:
         specifier: ^3.0.0
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)
+      react-reverse-portal:
+        specifier: ^2.3.0
+        version: 2.3.0(react-dom@18.2.0)(react@18.2.0)
       react-router-dom:
         specifier: ^6.11.0
         version: 6.11.0(react-dom@18.2.0)(react@18.2.0)
@@ -8425,6 +8428,16 @@ packages:
     dependencies:
       lodash.isequal: 4.5.0
       qrcode-generator: 1.4.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /react-reverse-portal@2.3.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-kvbPfLPKg6Y3S6tVq83us2RghvDpOS4GcJxbI7cZ0V0tuzUaSzblRIhVnKLOucfqF4lN/i9oWvEmpEi6bAOYlQ==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false


### PR DESCRIPTION
This pull request introduces a new `TimelineProvider` context to manage and render timelines using portals for improved state management and modularity. It also integrates the `react-reverse-portal` library to facilitate this functionality. The most important changes include the addition of the `TimelineProvider` component, updates to the `ListPage` to use the new context, and enhancements to the `RealtimeTimeline` component for better scroll position handling.

### Context Management and Timeline Integration:

* **`TimelineProvider` Component**: Added a new `TimelineProvider` context in `app/src/context/TimelineProvider.tsx` to manage timelines, including a portal-based rendering mechanism using `react-reverse-portal`. This component provides methods to set timelines and a reference to the virtualized list.
* **`ListPage` Updates**: Refactored `ListPage` to use the `TimelineProvider` context instead of directly managing timelines. This includes replacing the `RealtimeTimeline` component with an `OutPortal` for rendering timelines and updating the subscription logic to set timelines. [[1]](diffhunk://#diff-456ad28443a2d4ad222c0259019508313563cf5cdb25c0eaedc7d24270a76fb8R43-R44) [[2]](diffhunk://#diff-456ad28443a2d4ad222c0259019508313563cf5cdb25c0eaedc7d24270a76fb8L56-R62) [[3]](diffhunk://#diff-456ad28443a2d4ad222c0259019508313563cf5cdb25c0eaedc7d24270a76fb8L287-R293) [[4]](diffhunk://#diff-456ad28443a2d4ad222c0259019508313563cf5cdb25c0eaedc7d24270a76fb8L313-R320)

### Component Enhancements:

* **`RealtimeTimeline` Improvements**: Added a `useLayoutEffect` to restore scroll positions when navigating between paths and updated the `onRangeChange` callback to include the `start` parameter for better range handling. [[1]](diffhunk://#diff-9023453807b5457c5e5d99488495f1f649886f313be7e27186874f1f53e4cf98R148-R156) [[2]](diffhunk://#diff-9023453807b5457c5e5d99488495f1f649886f313be7e27186874f1f53e4cf98L164-R174)

### Dependency Updates:

* **`react-reverse-portal`**: Added `react-reverse-portal` version `2.3.0` to `package.json` and `pnpm-lock.yaml` to enable portal-based rendering for the `TimelineProvider`. [[1]](diffhunk://#diff-012b982f97a0d326aeec58dd3b789484b05a944d609afe1b8ed5e299fc485f61R64) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR186-R188) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8435-R8444)

### Code Cleanup:

* **Removed Unused Imports**: Cleaned up unused imports in `ListPage` after transitioning to the `TimelineProvider` context. [[1]](diffhunk://#diff-456ad28443a2d4ad222c0259019508313563cf5cdb25c0eaedc7d24270a76fb8L5) [[2]](diffhunk://#diff-456ad28443a2d4ad222c0259019508313563cf5cdb25c0eaedc7d24270a76fb8L21)

These changes collectively improve the modularity and maintainability of the timeline feature while enhancing user experience with better scroll position handling and state management.