### PR TITLE
add spotify&apple music embed

### DIFF
--- a/app/src/components/ui/GfmRenderer.tsx
+++ b/app/src/components/ui/GfmRenderer.tsx
@@ -192,36 +192,6 @@ export default function GfmRenderer(props: GfmRendererProps): JSX.Element {
                     },
                     a: ({ children, href }) => {
                         if (!href) return <></>
-                        let matchYoutubeVideo = href?.match(/https:\/\/www\.youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/)
-                        if (!matchYoutubeVideo) matchYoutubeVideo = href?.match(/https:\/\/youtu\.be\/([a-zA-Z0-9_-]+)/)
-                        if (matchYoutubeVideo) {
-                            return (
-                                <Box
-                                    component="span"
-                                    sx={{
-                                        display: 'block',
-                                        aspectRatio: '16 / 9',
-                                        overflow: 'hidden',
-                                        width: '100%',
-                                        borderRadius: 1,
-                                        maxWidth: '500px'
-                                    }}
-                                >
-                                    <iframe
-                                        allowFullScreen
-                                        src={`https://www.youtube.com/embed/${matchYoutubeVideo[1]}`}
-                                        title="YouTube video player"
-                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                        style={{
-                                            width: '100%',
-                                            height: '100%',
-                                            border: 'none'
-                                        }}
-                                    />
-                                </Box>
-                            )
-                        }
-
                         return (
                             <CCLink to={href} color="secondary" underline="hover">
                                 {children}

--- a/app/src/context/AutoSummaryContext.tsx
+++ b/app/src/context/AutoSummaryContext.tsx
@@ -125,6 +125,33 @@ export const AutoSummaryProvider = (props: AutoSummaryProviderProps): JSX.Elemen
                         )
                     }
 
+                    const matchAppleMusicLink = url?.match(/https:\/\/music\.apple\.com\/([^\s]+)/)
+                    if (matchAppleMusicLink) {
+                        return (
+                            <Box
+                                component="span"
+                                sx={{
+                                    display: 'block',
+                                    overflow: 'hidden',
+                                    width: '100%',
+                                    height: '152px',
+                                    borderRadius: 1
+                                }}
+                            >
+                                <iframe
+                                    allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
+                                    sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+                                    src={`https://embed.music.apple.com/${matchAppleMusicLink[1]}`}
+                                    style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        border: 'none'
+                                    }}
+                                />
+                            </Box>
+                        )
+                    }
+
                     return <UrlSummaryCard key={i} url={url} />
                 })}
             </Box>

--- a/app/src/context/AutoSummaryContext.tsx
+++ b/app/src/context/AutoSummaryContext.tsx
@@ -93,6 +93,38 @@ export const AutoSummaryProvider = (props: AutoSummaryProviderProps): JSX.Elemen
                             </Box>
                         )
                     }
+
+                    const matchSpotifyLink = url?.match(
+                        /https:\/\/open\.spotify\.com\/([-a-zA-Z0-9]+\/)?(track|album|playlist)\/([a-zA-Z0-9]+)/
+                    )
+                    if (matchSpotifyLink) {
+                        const type = matchSpotifyLink[2]
+                        const id = matchSpotifyLink[3]
+                        return (
+                            <Box
+                                component="span"
+                                sx={{
+                                    display: 'block',
+                                    overflow: 'hidden',
+                                    width: '100%',
+                                    height: '152px',
+                                    borderRadius: 1
+                                }}
+                            >
+                                <iframe
+                                    allowFullScreen
+                                    src={`https://open.spotify.com/embed/${type}/${id}`}
+                                    style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        border: 'none'
+                                    }}
+                                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                                />
+                            </Box>
+                        )
+                    }
+
                     return <UrlSummaryCard key={i} url={url} />
                 })}
             </Box>


### PR DESCRIPTION
This pull request enhances the handling of media links in the UI by adding support for embedding Spotify and Apple Music content, while removing the automatic embedding of YouTube videos. The changes improve the user experience for music links and simplify the code for YouTube links.

**Media Embedding Enhancements:**

* Added support for embedding Spotify tracks, albums, and playlists directly in the UI when a Spotify link is detected, providing a richer preview experience for users.
* Added support for embedding Apple Music content for detected Apple Music links, allowing users to interact with music previews without leaving the app.

**YouTube Embedding Removal:**

* Removed the automatic embedding of YouTube videos in the `GfmRenderer` component; YouTube links will now be shown as regular clickable links instead of embedded players.